### PR TITLE
Refatora fetch emendas camara

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,6 @@ variables:
   _R_CHECK_CRAN_INCOMING_: "false"
   _R_CHECK_FORCE_SUGGESTS_: "true"
   APT_PKGS: "libcurl4-openssl-dev libssh2-1-dev libssl-dev libxml2-dev zlib1g-dev git"
-  DOCKER_TLS_CERTDIR: ""
 
 cache:
   paths:

--- a/R/export_emendas.R
+++ b/R/export_emendas.R
@@ -4,20 +4,10 @@
 #' @param casa senado ou camara
 #' @export
 get_emendas <- function(id, casa) {
-  emendas <- tibble::tibble()
-  if (casa == 'camara') {
-    emendas_relacionadas <- rcongresso::fetch_relacionadas(casa, id) %>% 
-      dplyr::filter(stringr::str_starts(siglaTipo,'E'))
-  }
-  
-  # cat(paste(
-  #   "\n--- Processando: ", "\nid:", id,
-  #   "\ncasa", casa, "\n"))
-  # prop <- agoradigital::fetch_proposicao(id, casa)
-  # emendas <- 
-  #   rcongresso::fetch_emendas(id, casa, prop$sigla_tipo, prop$numero, prop$ano)
-  
-  emendas
+  cat(paste(
+    "\n--- Processando: ", "\nid:", id,
+    "\ncasa", casa, "\n"))
+  rcongresso::fetch_emendas(id, casa)
 }
 
 #' @title Safe get Emendas

--- a/R/export_emendas.R
+++ b/R/export_emendas.R
@@ -4,12 +4,18 @@
 #' @param casa senado ou camara
 #' @export
 get_emendas <- function(id, casa) {
-  cat(paste(
-    "\n--- Processando: ", "\nid:", id,
-    "\ncasa", casa, "\n"))
-  prop <- agoradigital::fetch_proposicao(id, casa)
-  emendas <- 
-    rcongresso::fetch_emendas(id, casa, prop$sigla_tipo, prop$numero, prop$ano)
+  emendas <- tibble::tibble()
+  if (casa == 'camara') {
+    emendas_relacionadas <- rcongresso::fetch_relacionadas(casa, id) %>% 
+      dplyr::filter(stringr::str_starts(siglaTipo,'E'))
+  }
+  
+  # cat(paste(
+  #   "\n--- Processando: ", "\nid:", id,
+  #   "\ncasa", casa, "\n"))
+  # prop <- agoradigital::fetch_proposicao(id, casa)
+  # emendas <- 
+  #   rcongresso::fetch_emendas(id, casa, prop$sigla_tipo, prop$numero, prop$ano)
   
   emendas
 }

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -21,7 +21,7 @@ import_proposicao <- function(prop_id, casa, apelido, tema, out_folderpath=NULL)
   
   prop_df <- fetch_proposicao(prop_id,casa,apelido, tema)
   tram_df <- fetch_tramitacao(prop_id,casa)
-  emendas_df <- rcongresso::fetch_emendas(prop_id,casa, prop_df$tipo_materia, prop_df$numero, prop_df$ano)
+  emendas_df <- rcongresso::fetch_emendas(prop_id,casa)
   
   if (!is.null(out_folderpath)) {
     if (!is.null(prop_df)) readr::write_csv(prop_df, build_data_filepath(out_folderpath,'proposicao',casa,prop_id))

--- a/R/textos_proposicao.R
+++ b/R/textos_proposicao.R
@@ -127,8 +127,7 @@ extract_links_proposicao_camara <- function(proposicao_df, tramitacao_df) {
   
   tipos_emendas <- camara_env$tipos_emendas
   
-  emendas <- rcongresso::fetch_emendas(proposicao_df$id, casa, proposicao_df$siglaTipo, 
-                                       proposicao_df$numero, proposicao_df$ano) %>% 
+  emendas <- rcongresso::fetch_emendas(proposicao_df$id, casa) %>% 
     
     dplyr::mutate(prop_id = proposicao_df$id,
                   casa = "camara")  %>% 


### PR DESCRIPTION
## Mudanças
- Refatora função get_emendas e outras funções que chamavam o fetch_emendas do rcongresso no pacote agoradigital, adequando-as ao novo padrão da chamada do fetch_emendas do rcongresso:
  + Removendo parâmetros sigla, ano e número, que não são mais necessários
  + Eliminando a chamada à função fetch_proposicao para pegar a sigla, ano e numero, não mais necessários.

## Como Testar
- Necessita [desse PR do rcongresso](https://github.com/analytics-ufcg/rcongresso/pull/178)
- Para testar esse PR, deve-se fazer chamadas ao fetch_emendas e o resultado deve bater com o encontrado na página da proposição na Câmara. Um exemplo curto é a da Lei do FUNDEB na Câmara, cujo id é 1198512