### PR TITLE
Adiciona coluna com nome do interesse ao csv com o mapeamento dos interesses

### DIFF
--- a/tests/testthat/test-analyzer.R
+++ b/tests/testthat/test-analyzer.R
@@ -62,7 +62,7 @@ test_that('process_proposicao() retorna abertura e encerramento do prazo das eme
 test_that('extract_autor_in_camara() returns the right cols and author', {
   autor_camara <- agoradigital::extract_autor_in_camara(2121442)
   expect_true(all(sapply(autor_camara, class) %in% .COLNAMES_AUTOR_CAMARA))
-  expect_true(autor_camara$autor.nome == "Senado Federal - Comissão Especial do Extrateto SF ")
+  expect_true(autor_camara$autor.nome == "Senado Federal - Comissão Especial do Extrateto SF /")
   
 })
 


### PR DESCRIPTION
## Mudanças
- Captura nome do interesse direto da tabela com listagem dos interesses para processamento.

## Flags
- Pode ser avaliada considerando a versão master do [leggo-geral](https://github.com/parlametria/leggo-geral)
- Foi desenvolvido usando a tabela de desenvolvimento:
URL_INTERESSES="https://docs.google.com/spreadsheets/d/e/2PACX-1vTOdLk1wxJsekjGF5alyD0AP25wVtpnq0QTy6IZTebY_WSiiAF6Any-_BWRTpcerTHHW4zJL3Y9hHpf/pub?gid=0&single=true&output=csv"

- Após revisão e aprovação será necessário adicionar a coluna "nome" na planilha de interesses usada em produção.


