### PR TITLE
Melhora processamento de autorias e classificação de documentos para o Senado

### DIFF
--- a/R/config/environment_senado.json
+++ b/R/config/environment_senado.json
@@ -53,7 +53,7 @@
     "evento_abertura": "inicio_prazo_emendas",
     "evento_fim": "fim_prazo_emendas"
   },
-  
+
   "evento": {
     "realizacao_audiencia_publica": {
       "regex": "realizada(,)* (.)*audiência pública",
@@ -216,25 +216,25 @@
   },
 
   "tipos_documentos": [
-    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|mpv|plc|pls|pl", "peso": 1},
+    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|mpv|plc|pls|pl|projeto de decreto legislativo", "peso": 1},
     {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 2},
     {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3},
-    {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4}, 
+    {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4},
     {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5}
     ],
-    
+
   "tipos_documentos_scrap": [
     {"tipo": "Emenda", "regex": "emenda|subemenda"},
     {"tipo": "Parecer", "regex": "parecer|^complementa..o de voto|^reda..o final|^substitutivo|p\\.s|^relat(ó|o)rio|^par"},
-    {"tipo": "Requerimento", "regex": "requerimento|rqe|rqs|rqj|rra|req|rdh|rma"}, 
+    {"tipo": "Requerimento", "regex": "requerimento|rqe|rqs|rqj|rra|req|rdh|rma"},
     {"tipo": "Voto em Separado", "regex": "voto em separado"}
     ],
-    
+
   "tipos_autores_scrap": [
     {"tipo_autor": "senador", "regex": "^Senador(a)*|^Líder do ((.*?)(\\s))|^Presidente do Senado Federal: Senador"},
     {"tipo_autor": "deputado", "regex": "^Deputad(o|a)|^Deputad(o|a) Federal"}
   ],
-  
+
   "tipos_emendas": [
     {"descricao_tipo_texto": "Emenda"},
     {"descricao_tipo_texto": "Subemenda"},

--- a/R/prepare_coautorias_data.R
+++ b/R/prepare_coautorias_data.R
@@ -275,14 +275,17 @@ get_coautorias <- function(docs, autores, casa, limiar = 0.1, partidos_oposicao,
 prepare_autorias_df_camara <- function(docs_camara, autores_camara) {
   autores_docs <-
     merge(docs_camara, autores_camara, by = c("id_principal", "id_documento", "casa")) %>%
-        dplyr::select(id_principal,
-                      casa,
-                      id_documento,
-                      descricao_tipo_documento,
-                      id_autor,
-                      data,
-                      url_inteiro_teor,
-                      id_leggo) %>%
+    dplyr::mutate(tipo_documento_ext = descricao_tipo_documento) %>% ## padroniza com dataframe do senado
+    dplyr::select(
+      id_principal,
+      casa,
+      id_documento,
+      descricao_tipo_documento,
+      tipo_documento_ext,
+      id_autor,
+      data,
+      url_inteiro_teor,
+      id_leggo) %>%
     dplyr::distinct()
 }
 
@@ -299,6 +302,7 @@ prepare_autorias_df_senado <- function(docs_senado, autores_senado) {
                   casa,
                   id_documento,
                   descricao_tipo_documento = descricao_texto,
+                  tipo_documento_ext = descricao_tipo_texto,
                   id_autor,
                   data,
                   url_inteiro_teor = url_texto,

--- a/R/prepare_coautorias_data.R
+++ b/R/prepare_coautorias_data.R
@@ -8,19 +8,19 @@
 #' @export
 compute_nodes_size <- function(final_edges, final_nodes, smoothing = 1) {
   final_edges <-
-    final_edges %>% 
+    final_edges %>%
     dplyr::mutate(value = dplyr::if_else(source == target, value/2, value))
   nodes_size_source <-
     final_edges %>%
     dplyr::group_by(node = source, id_leggo) %>%
     dplyr::summarise(node_size = sum(value)) %>%
-    dplyr::ungroup() %>% 
+    dplyr::ungroup() %>%
     dplyr::mutate(node = as.character(node))
   nodes_size_target <-
     final_edges %>%
     dplyr::group_by(node = target, id_leggo) %>%
     dplyr::summarise(node_size = sum(value)) %>%
-    dplyr::ungroup() %>% 
+    dplyr::ungroup() %>%
     dplyr::mutate(node = as.character(node))
   nodes_size <-
     dplyr:: bind_rows(nodes_size_source,nodes_size_target) %>%
@@ -41,16 +41,16 @@ compute_nodes_size <- function(final_edges, final_nodes, smoothing = 1) {
 generate_nodes <- function(coautorias) {
   graph_nodes <-
       dplyr::bind_rows(
-      coautorias %>% dplyr::select(id_autor = id_autor.x, nome = nome.x, partido = partido.x, 
+      coautorias %>% dplyr::select(id_autor = id_autor.x, nome = nome.x, partido = partido.x,
                                    uf = uf.x, bancada = bancada.x, casa_autor = casa_autor.x),
-      coautorias %>% dplyr::select(id_autor = id_autor.y, nome = nome.y, partido = partido.y, 
+      coautorias %>% dplyr::select(id_autor = id_autor.y, nome = nome.y, partido = partido.y,
                                    uf = uf.y, bancada = bancada.y, casa_autor = casa_autor.y)) %>%
       dplyr::distinct()
 
   final_nodes <- graph_nodes %>%
     tibble::as_tibble() %>%
     dplyr::mutate(nome_eleitoral = purrr::pmap_chr(list(nome, partido, uf), ~ agoradigital::formata_nome_eleitoral(..1, ..2, ..3)))
-  
+
   return(final_nodes)
 }
 
@@ -62,22 +62,22 @@ generate_nodes <- function(coautorias) {
 #' @export
 get_unique_nodes <- function(coautorias) {
   nodes <-
-    coautorias %>% 
-    dplyr::group_by(id_leggo) %>% 
-    dplyr::group_modify(~ agoradigital::generate_nodes(.), keep = T) %>% 
+    coautorias %>%
+    dplyr::group_by(id_leggo) %>%
+    dplyr::group_modify(~ agoradigital::generate_nodes(.), keep = T) %>%
     dplyr::ungroup()
-  
+
   unique_nodes <-
-    nodes %>% 
-    dplyr::group_by(id_leggo, id_autor, casa_autor) %>% 
+    nodes %>%
+    dplyr::group_by(id_leggo, id_autor, casa_autor) %>%
     dplyr::summarise(nome = dplyr::first(nome),
                      partido = dplyr::first(partido),
                      uf = dplyr::first(uf),
                      bancada = dplyr::first(bancada),
                      nome_eleitoral = dplyr::first(nome_eleitoral))
-  
-  nodes %>% 
-    dplyr::inner_join(unique_nodes, by = c("id_leggo", "id_autor", "casa_autor", "nome", "partido", 
+
+  nodes %>%
+    dplyr::inner_join(unique_nodes, by = c("id_leggo", "id_autor", "casa_autor", "nome", "partido",
                                            "uf", "bancada", "nome_eleitoral"))
 }
 
@@ -89,20 +89,20 @@ get_unique_nodes <- function(coautorias) {
 #' @return Dataframes de arestas
 #' @export
 generate_edges <- function(coautorias, graph_nodes, edges_weight = 1) {
-  coautorias_index <- 
+  coautorias_index <-
     coautorias %>%
     dplyr::left_join(graph_nodes %>%  dplyr::select(id_autor), by=c("id_autor.x"="id_autor")) %>%
     dplyr::left_join(graph_nodes %>%  dplyr::select(id_autor), by=c("id_autor.y"="id_autor"))
-  
+
   graph_edges <- coautorias_index %>%
     dplyr::select(
       source = id_autor.x,
       target = id_autor.y,
-      value = peso_arestas) 
-  
+      value = peso_arestas)
+
   final_edges <- graph_edges %>%
     tibble::as_tibble() %>%
-    dplyr::mutate(value = value*edges_weight) %>% 
+    dplyr::mutate(value = value*edges_weight) %>%
     dplyr::distinct()
 }
 
@@ -117,7 +117,7 @@ remove_duplicated_edges <- function(df) {
     deduplicated_df <- df %>%
       dplyr::mutate(col_pairs = dplyr::if_else(id_autor.x > id_autor.y,
                                                paste0(id_autor.y, ":", id_autor.x),
-                                               paste0(id_autor.x, ":", id_autor.y))) %>% 
+                                               paste0(id_autor.x, ":", id_autor.y))) %>%
       dplyr::distinct(id_leggo, id_documento, col_pairs, peso_arestas) %>%
       tidyr::separate(col = col_pairs,
                       c("id_autor.x",
@@ -128,7 +128,7 @@ remove_duplicated_edges <- function(df) {
 }
 
 #' @title Cria o dataframe de coautorias sem os dados de parlamentares
-#' @description  Recebe o dataframe de autorias, pesos e o limiar e retorna o dataframe 
+#' @description  Recebe o dataframe de autorias, pesos e o limiar e retorna o dataframe
 #' de coautorias raw
 #' @param autorias Dataframe com as autorias
 #' @param limiar Peso mínimo das arestas
@@ -136,58 +136,58 @@ remove_duplicated_edges <- function(df) {
 #' @return Dataframe de coautorias para documentos de uma casa de origem.
 get_coautorias_raw <- function(autorias, limiar, casa_origem) {
   # Filtra autorias apenas para casa de origem
-  autorias <- autorias %>% 
+  autorias <- autorias %>%
     dplyr::filter(casa == casa_origem)
-  
-  # Calcula o número de autores e o peso das arestas (filtra usando um limiar) 
+
+  # Calcula o número de autores e o peso das arestas (filtra usando um limiar)
   num_autorias_por_pl <- autorias %>%
-    dplyr::group_by(id_leggo, id_documento) %>% 
+    dplyr::group_by(id_leggo, id_documento) %>%
     dplyr::summarise(num_autores = dplyr::n_distinct(id_autor),
-                     peso_arestas = 1/dplyr::n_distinct(id_autor)) %>% 
-    dplyr::ungroup() %>% 
+                     peso_arestas = 1/dplyr::n_distinct(id_autor)) %>%
+    dplyr::ungroup() %>%
     dplyr::filter(peso_arestas >= limiar)
 
   # Obtem informações dos documentos
-  coautorias_raw_info <- autorias %>% 
+  coautorias_raw_info <- autorias %>%
     dplyr::distinct(id_leggo, id_principal, casa, id_documento, data)
-  
+
   # Garbage collection
   gc()
-  
+
   # Gera dataframe de coautorias
   coautorias_raw <- autorias %>%
-    dplyr::select(id_leggo, id_documento, id_autor) %>% 
-    dplyr::full_join(autorias %>% 
-                       dplyr::select(id_leggo, id_documento, id_autor), 
+    dplyr::select(id_leggo, id_documento, id_autor) %>%
+    dplyr::full_join(autorias %>%
+                       dplyr::select(id_leggo, id_documento, id_autor),
                      by = c("id_leggo", "id_documento"))
   gc()
 
-  coautorias_simples <- coautorias_raw %>% 
+  coautorias_simples <- coautorias_raw %>%
     dplyr::inner_join(num_autorias_por_pl %>% dplyr::filter(num_autores == 1),
                       by=c("id_documento", "id_leggo"))
-  
-  coautorias_multiplas <- coautorias_raw %>% 
+
+  coautorias_multiplas <- coautorias_raw %>%
     dplyr::inner_join(num_autorias_por_pl %>% dplyr::filter(num_autores > 1),
-                      by=c("id_documento", "id_leggo")) %>% 
+                      by=c("id_documento", "id_leggo")) %>%
     dplyr::filter(id_autor.x != id_autor.y)
-  
+
   # Remove dataframe não mais usado e chama garbage collector.
   rm(coautorias_raw)
   gc()
-  
-  coautorias <- dplyr::bind_rows(coautorias_simples, coautorias_multiplas) %>% 
+
+  coautorias <- dplyr::bind_rows(coautorias_simples, coautorias_multiplas) %>%
     dplyr::select(-num_autores) %>%
     dplyr::distinct()
-  
+
   # Remove dataframe não mais utilizado
   rm(coautorias_multiplas)
   gc()
-  
+
   # Remove arestas duplicadas, cruza com informações dos documentos e calcula peso final para as arestas
   coautorias %>%
     remove_duplicated_edges() %>%
     dplyr::left_join(coautorias_raw_info,
-                     by = c("id_leggo", "id_documento")) %>% 
+                     by = c("id_leggo", "id_documento")) %>%
     dplyr::group_by(id_leggo, id_principal, casa, id_autor.x, id_autor.y) %>%
     dplyr::summarise(peso_arestas = sum(peso_arestas),
                      num_coautorias = dplyr::n()) %>%
@@ -204,12 +204,13 @@ get_coautorias_raw <- function(autorias, limiar, casa_origem) {
 #' @param casa camara ou senado
 #' @param limiar Peso mínimo das arestas
 #' @param partidos_oposicao lista com os partidos da oposição
+#' @param data_inicial Data inicial para considerar coautorias
 #' @return Dataframe
 #' @export
-get_coautorias <- function(docs, autores, casa, limiar = 0.1, partidos_oposicao) {
+get_coautorias <- function(docs, autores, casa, limiar = 0.1, partidos_oposicao, data_inicial = NULL) {
   autorias <- tibble::tibble()
   coautorias <- tibble::tibble()
-  
+
   if (casa == 'camara') {
     autorias <- agoradigital::prepare_autorias_df_camara(docs, autores)
   } else {
@@ -217,38 +218,47 @@ get_coautorias <- function(docs, autores, casa, limiar = 0.1, partidos_oposicao)
     autores <- autores %>%
       rename(nome = nome_autor)
   }
-  
-  parlamentares <- autores %>% 
+
+  parlamentares <- autores %>%
     mutate(casa_autor = if_else(tolower(tipo_autor) == "deputado",
                                 "camara",
-                                "senado")) %>% 
-    group_by(id_autor) %>% 
+                                "senado")) %>%
+    group_by(id_autor) %>%
     summarise(nome = first(nome),
+
               partido = last(partido),
               uf = first(uf),
-              casa_autor = first(casa_autor)) %>% 
+              casa_autor = first(casa_autor)) %>%
     ungroup()
-  
-  coautorias <- get_coautorias_raw(autorias, limiar, casa)
-  
+
+  ## Filtra autorias passadas como parâmetro para coautorias com base na data_inicial
+  if (!is.null(data_inicial)) {
+    autorias_filtradas <- autorias %>%
+      dplyr::filter(data > data_inicial)
+  } else {
+    autorias_filtradas <- autorias
+  }
+
+  coautorias <- get_coautorias_raw(autorias_filtradas, limiar, casa)
+
   if (nrow(coautorias) > 0) {
     autorias <-
-      autorias %>% 
-      dplyr::left_join(parlamentares, by = "id_autor") %>% 
-      dplyr::distinct() %>% 
-      dplyr::mutate(nome_eleitoral = purrr::pmap_chr(list(nome, partido, uf), 
-                                                     ~ agoradigital::formata_nome_eleitoral(..1, ..2, ..3))) %>% 
+      autorias %>%
+      dplyr::left_join(parlamentares, by = "id_autor") %>%
+      dplyr::distinct() %>%
+      dplyr::mutate(nome_eleitoral = purrr::pmap_chr(list(nome, partido, uf),
+                                                     ~ agoradigital::formata_nome_eleitoral(..1, ..2, ..3))) %>%
       dplyr::select(-c(nome, partido, uf))
-    
+
     parlamentares <-
-      parlamentares %>% 
+      parlamentares %>%
       dplyr::mutate(bancada = dplyr::if_else(partido %in% partidos_oposicao, "oposição", "governo"))
-  
-    coautorias <- 
+
+    coautorias <-
       coautorias %>%
       dplyr::inner_join(parlamentares, by = c("id_autor.x" = "id_autor")) %>%
       dplyr::inner_join(parlamentares, by = c("id_autor.y" = "id_autor")) %>%
-      dplyr::distinct() 
+      dplyr::distinct()
   } else {
     autorias <- tibble::tibble()
   }
@@ -290,7 +300,7 @@ prepare_autorias_df_senado <- function(docs_senado, autores_senado) {
                   id_documento,
                   descricao_tipo_documento = descricao_texto,
                   id_autor,
-                  data = data_texto,
+                  data,
                   url_inteiro_teor = url_texto,
                   id_leggo) %>%
     dplyr::distinct()

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -537,10 +537,11 @@ match_autores_senado_scrap_to_deputados <- function(autores_senado_scrap_deputad
 }
 
 #' @title Classifica o tipo de documento com base na coluna com a descrição do tipo de documento.
-#' @description A partir da coluna descricao_tipo_documento, classifica o tipo do documento em grupos principais
+#' @description A partir da coluna descricao_tipo_documento ou tipo_documento_ext, classifica o tipo do documento em grupos principais
 #' como emendas, requerimentos, projetos de lei, etc.
 #' @param docs Dataframe com informação do tipo de documento a serem classificados.
 #' (é necessário ter as colunas casa, descricao_tipo_documento, id_principal, id_documento, id_autor).
+#' Para o Senado a coluna utilizada para classificar o tipo de documento é tipo_documento_ext.
 #' @return Dataframe contendo uma coluna a mais com o tipo_documento
 #' @examples classifica_tipo_documento_autorias(autorias)
 #' @export
@@ -553,7 +554,7 @@ classifica_tipo_documento_autorias <- function(docs) {
 
   docs_senado <- docs %>%
     filter(casa == "senado") %>%
-    fuzzyjoin::regex_left_join(senado_env$tipos_documentos, by = c(descricao_tipo_documento = "regex"), ignore_case = T) %>%
+    fuzzyjoin::regex_left_join(senado_env$tipos_documentos, by = c(tipo_documento_ext = "regex"), ignore_case = T) %>%
     dplyr::mutate(tipo = dplyr::if_else(is.na(tipo), "Outros", tipo), # default para tipos não agrupados
                   tipo = dplyr::if_else(str_detect(tipo, "P.S"), "Outros", tipo), # Corrige casos de falsos positivos em matérias legislativas.
                   peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso))) %>% # Atribui peso default

--- a/scripts/documentos/export_coautorias.R
+++ b/scripts/documentos/export_coautorias.R
@@ -15,12 +15,13 @@
   camara_documentos <-
     camara_docs %>%
     dplyr::mutate(data = lubridate::floor_date(data_apresentacao, unit='day')) %>%
-    dplyr::filter(data > data_inicial) %>%
     dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
 
   # Gerando dado de autorias de documentos
   if (nrow(camara_documentos) > 0) {
-    coautorias_camara_list <- agoradigital::get_coautorias(camara_documentos, camara_autores, "camara", as.numeric(peso_minimo), .PARTIDOS_OPOSICAO)
+    coautorias_camara_list <- agoradigital::get_coautorias(camara_documentos, camara_autores, "camara",
+                                                           as.numeric(peso_minimo), .PARTIDOS_OPOSICAO,
+                                                           data_inicial)
     coautorias_camara <- coautorias_camara_list$coautorias
     autorias_camara <- coautorias_camara_list$autorias
   }
@@ -64,12 +65,14 @@
 
   senado_documentos <-
     senado_docs %>%
-    dplyr::filter(data_texto > data_inicial) %>%
+    dplyr::rename(data = data_texto) %>%
     dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
 
   # Gerando dado de autorias de documentos
   if (nrow(senado_documentos) > 0) {
-    coautorias_senado_list <- agoradigital::get_coautorias(senado_documentos, senado_autores, "senado", as.numeric(peso_minimo), .PARTIDOS_OPOSICAO)
+    coautorias_senado_list <- agoradigital::get_coautorias(senado_documentos, senado_autores, "senado",
+                                                           as.numeric(peso_minimo), .PARTIDOS_OPOSICAO,
+                                                           data_inicial)
     coautorias_senado <- coautorias_senado_list$coautorias
     autorias_senado <- coautorias_senado_list$autorias
   }

--- a/scripts/documentos/export_coautorias.R
+++ b/scripts/documentos/export_coautorias.R
@@ -41,8 +41,8 @@
     coautorias <- tibble::tibble(~id_leggo, ~id_principal, ~casa, ~id_autor.x, ~id_autor.y, ~peso_arestas, ~num_coautorias,
                                  ~nome.x, ~partido.x, ~uf.x, ~casa_autor.x, ~bancada.x, ~nome.y, ~partido.y, ~uf.y, ~casa_autor.y,
                                  ~bancada.y)
-    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~id_autor, ~data,
-                                ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores)
+    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~tipo_documento_ext,
+                                ~id_autor, ~data, ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores)
   }
 
   readr::write_csv(coautorias, paste0(output_path, '/camara/coautorias.csv'))
@@ -92,8 +92,8 @@
     coautorias <- tibble::tibble(~id_leggo, ~id_principal, ~casa, ~id_autor.x, ~id_autor.y, ~peso_arestas, ~num_coautorias,
                                  ~nome.x, ~partido.x, ~uf.x, ~casa_autor.x, ~bancada.x, ~nome.y, ~partido.y, ~uf.y,
                                  ~casa_autor.y, ~bancada.y)
-    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~id_autor, ~data,
-                                ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores)
+    autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, tipo_documento_ex,
+                                ~id_autor, ~data, ~url_inteiro_teor, ~id_leggo, ~casa_autor, ~nome_eleitoral, ~autores)
   }
 
   readr::write_csv(coautorias, paste0(output_path, '/senado/coautorias.csv'))
@@ -138,7 +138,8 @@ export_nodes_edges <- function(input_path, camara_docs, data_inicial, senado_doc
       dplyr::distinct() %>%
       dplyr::mutate(id_autor_parlametria = paste0(dplyr::if_else(casa_autor == "camara", 1, 2),
                                                   id_autor)) %>%
-      agoradigital::classifica_tipo_documento_autorias()
+      agoradigital::classifica_tipo_documento_autorias() %>%
+      dplyr::select(-tipo_documento_ext)
 
     nodes <-
       agoradigital::get_unique_nodes(coautorias)


### PR DESCRIPTION
## Mudanças
- Passa a considerar documentos a partir de qualquer data nos dados de autorias. Antes havia um filtro de data.
- Considera o filtro de data apenas para os dados sumarizados de coautorias (nodes e edges consequentemente)
- Passa a usar coluna com a classificação do tipo de documento disponibilizada pelo Senado. Houve melhora na classificação de proposições (PECs principalmente).

