### PR TITLE
Adiciona anotações gerais ao leggo

### DIFF
--- a/scripts/anotacoes/export_anotacoes.R
+++ b/scripts/anotacoes/export_anotacoes.R
@@ -4,11 +4,11 @@ source(here::here("scripts/anotacoes/process_anotacoes.R"))
 
 .HELP <- "
 Usage:
-Rscript export_anotacoes.R -u <url_lista_anotacoes> -i <pls_interesses_filepath> -p <proposicoes_filepath> -e <export_filepath>
+Rscript export_anotacoes.R -u <url_lista_anotacoes> -i <pls_interesses_filepath> -p <proposicoes_filepath> -e <export_path>
 url_lista_anotacoes: Link para o csv com todas as URL's contendo as anotações para todos os interesses
 pls_interesses_filepath: Caminho para o csv com o mapeamento de pls a interesses
 proposicoes_filepath: Caminho para o csv de proposições processadas pelo Leggo
-export_filepath: Caminho para exportação das anotação
+export_path: Caminho do diretório destino para exportação das anotações gerais e específicas
 "
 
 #' @title Get arguments from command line option parsing
@@ -32,9 +32,9 @@ get_args <- function() {
                           default="",
                           help=.HELP,
                           metavar="character"),
-    optparse::make_option(c("-e", "--export_filepath"),
+    optparse::make_option(c("-e", "--export_path"),
                           type="character",
-                          default="../../data/anotacoes.csv",
+                          default="../../data/",
                           help=.HELP,
                           metavar="character")
   );
@@ -51,11 +51,12 @@ print(args)
 url_lista_anotacoes <- args$url
 pls_interesses <- args$pls_interesses_filepath
 proposicoes <- args$proposicoes_filepath
-saida <- args$export_filepath
+export_path <- args$export_path
 
 print("Baixando e processando os dados de anotações...")
 anotacoes <- processa_anotacoes(url_lista_anotacoes, pls_interesses, proposicoes)
 
 print("Salvando anotacoes...")
-readr::write_csv(anotacoes, saida)
+readr::write_csv(anotacoes$anotacoes_gerais, paste0(export_path, "/anotacoes_gerais.csv"))
+readr::write_csv(anotacoes$anotacoes_especificas, paste0(export_path, "/anotacoes_especificas.csv"))
 print("Salvo")

--- a/scripts/anotacoes/process_anotacoes.R
+++ b/scripts/anotacoes/process_anotacoes.R
@@ -1,14 +1,13 @@
 #' @title Baixa as anotações dos interesses do leggo
-#' @description A partir de uma lista de anotações com interesses atrelados, 
+#' @description A partir de uma lista de anotações com interesses atrelados,
 #' baixa os dados de anotações e mapeia os interesses correspondentes.
 #' @param url URL para lista de anotações por interesse do leggo
 #' @return Dataframe com o mapeamento entre anotações e interesses
-#' contendo data_criacao, data_ultima_modificacao, proposicao, 
-#' autor, titulo, anotacao, interesse 
+#' contendo data_criacao, data_ultima_modificacao, proposicao,
+#' autor, titulo, anotacao, interesse
 #' @example
 #' anotacoes <- .processa_lista_anotacoes(url)
 .processa_lista_anotacoes <- function(url) {
-  
   if (is.null(url) | url == "") {
     stop("URL para planilha de anotações precisa ser diferente de vazio e não nula.")
   }
@@ -49,57 +48,73 @@
 #' @param url URL para lista de anotações por interesse do leggo
 #' @param pls_interesses_datapath Caminho do arquivo do dataframe que possui
 #' os identificadores, interesses e proposições mapeados.
-#' @param proposicoes_datapath Caminho do caminho do dataframe que possui 
+#' @param proposicoes_datapath Caminho do caminho do dataframe que possui
 #' o identificador do leggo para as proposições.
 #' @return Dataframe com o mapeamento entre anotações e interesses
-#' contendo data_criacao, data_ultima_modificacao, proposicao, 
-#' autor, titulo, anotacao, interesse, id_ext, casa, id_leggo. 
+#' contendo data_criacao, data_ultima_modificacao, proposicao,
+#' autor, titulo, anotacao, interesse, id_ext, casa, id_leggo.
 #' @example
 #' anotacoes <- processa_anotacoes(url, pls_interesses_datapath, proposicoes_datapath)
-processa_anotacoes <- function(url, pls_interesses_datapath, proposicoes_datapath) {
-  library(tidyverse)
-  
-  anotacoes <- .processa_lista_anotacoes(url)
-  
-  anotacoes <- anotacoes %>%
-    dplyr::mutate_at(vars("data_criacao", "data_ultima_modificacao"),
-                     ~ lubridate::mdy_hms(.)) %>% 
-    dplyr::mutate(peso = if_else(is.na(peso), 99, as.numeric(peso)))
-  
-  pls_interesses <- readr::read_csv(pls_interesses_datapath,
-                                    col_types = cols(.default = "c")) %>%
-    dplyr::select(proposicao, id_camara, id_senado)
-  
-  anotacoes_com_ids <- anotacoes %>% 
-    dplyr::left_join(pls_interesses, by = c("proposicao")) %>% 
-    dplyr::select(-proposicao)
-  
-  anotacoes_com_ids_camara <- anotacoes_com_ids %>%
-    dplyr::mutate(id_ext = id_camara) %>%
-    dplyr::filter(!is.na(id_ext)) %>%
-    dplyr::select(-c(id_senado, id_camara))
-  
-  anotacoes_com_ids_senado <- anotacoes_com_ids %>%
-    dplyr::mutate(id_ext = id_senado) %>%
-    dplyr::filter(!is.na(id_ext)) %>%
-    dplyr::select(-c(id_senado, id_camara))
-  
-  anotacoes_com_ids <- anotacoes_com_ids_camara %>%
-    dplyr::bind_rows(anotacoes_com_ids_senado)
-  
-  proposicoes <-
-    readr::read_csv(proposicoes_datapath, col_types = cols(.default = "c")) %>%
-    dplyr::select(id_leggo, id_ext)
-  
-  anotacoes_com_ids_processed <- proposicoes %>%
-    dplyr::inner_join(anotacoes_com_ids, by = "id_ext") %>% 
-    dplyr::select(-id_ext) %>% 
-    dplyr::distinct() %>% 
-    dplyr::mutate(
-      categoria = iconv(categoria, 
-                        from="UTF-8", 
-                        to="ASCII//TRANSLIT") %>% 
-        tolower())
-  
-  return(anotacoes_com_ids_processed)
-}
+processa_anotacoes <-
+  function(url,
+           pls_interesses_datapath,
+           proposicoes_datapath) {
+    library(tidyverse)
+    
+    anotacoes <- .processa_lista_anotacoes(url)
+    
+    anotacoes <- anotacoes %>%
+      dplyr::mutate_at(vars("data_criacao", "data_ultima_modificacao"),
+                       ~ lubridate::mdy_hms(.)) %>%
+      dplyr::mutate(
+        peso = if_else(is.na(peso), 99, as.numeric(peso)),
+        proposicao = str_remove(proposicao, "CD |SF |CN "),
+        categoria = iconv(categoria,
+                          from = "UTF-8",
+                          to = "ASCII//TRANSLIT") %>%
+          tolower(),
+        is_insight_geral = if_else(is.na(proposicao), 1, 0)
+      )
+    
+    pls_interesses <- readr::read_csv(pls_interesses_datapath,
+                                      col_types = cols(.default = "c")) %>%
+      dplyr::select(proposicao, id_camara, id_senado)
+    
+    anotacoes_com_ids <- anotacoes %>%
+      dplyr::left_join(pls_interesses, by = c("proposicao")) %>%
+      dplyr::select(-proposicao)
+    
+    anotacoes_com_ids_camara <- anotacoes_com_ids %>%
+      dplyr::mutate(id_ext = id_camara) %>%
+      dplyr::filter(!is.na(id_ext), is_insight_geral == 0) %>%
+      dplyr::select(-c(id_senado, id_camara, is_insight_geral))
+    
+    anotacoes_com_ids_senado <- anotacoes_com_ids %>%
+      dplyr::mutate(id_ext = id_senado) %>%
+      dplyr::filter(!is.na(id_ext), is_insight_geral == 0) %>%
+      dplyr::select(-c(id_senado, id_camara, is_insight_geral))
+    
+    anotacoes_gerais <- anotacoes %>%
+      dplyr::filter(is_insight_geral == 1) %>%
+      dplyr::select(-c(proposicao, is_insight_geral)) %>%
+      dplyr::distinct()
+    
+    anotacoes_com_ids <- anotacoes_com_ids_camara %>%
+      dplyr::bind_rows(anotacoes_com_ids_senado)
+    
+    proposicoes <-
+      readr::read_csv(proposicoes_datapath, col_types = cols(.default = "c")) %>%
+      dplyr::select(id_leggo, id_ext)
+    
+    anotacoes_com_ids_processed <- proposicoes %>%
+      dplyr::inner_join(anotacoes_com_ids, by = "id_ext") %>%
+      dplyr::select(-id_ext) %>%
+      dplyr::distinct()
+    
+    return(
+      list(
+        anotacoes_gerais = anotacoes_gerais,
+        anotacoes_especificas = anotacoes_com_ids_processed
+      )
+    )
+  }


### PR DESCRIPTION
**Mudanças deste PR**:
- Modificar script que processa os dados de insights, adicionando uma lista com o dataframe de insights gerais (que não possuem nenhuma proposição associada) e de insights_especificos;
- Alterar script que exporta esses dados, adicionando argumento de caminho para pasta destino que conterá os arquivos `anotacoes_gerais.csv` e `anotacoes_especificas.csv`.

**OBS:** A url com a lista de anotações versão dev está aqui para auxiliar nos testes: https://docs.google.com/spreadsheets/d/e/2PACX-1vQIC9sm_jTojACKqzF17nPU8qiQRmWSeaKDOeRuxkLnhSZwOwdx0GpgGflpJigM3-N_KOPBz85-wR_u/pub?gid=0&single=true&output=csv