### PR TITLE
Melhora ordem do build de dependências da imagem do leggoR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,12 @@ RUN apt-get install libssl-dev libxml2-dev libcurl4-openssl-dev vim less git -y
 COPY DESCRIPTION .
 RUN Rscript -e 'update.packages(checkBuilt=TRUE, ask=FALSE)'
 RUN Rscript -e 'install.packages("devtools"); devtools::install_deps()'
+RUN Rscript -e 'devtools::install_version("dplyr", version = "0.8.5", repos = "http://cran.us.r-project.org")'
 COPY . .
 
 #Install rcongresso from local branch
 ARG clone_rcongresso=true
 RUN if [ "$clone_rcongresso" = "false" ] ;  then Rscript -e 'devtools::install("rcongresso/")'; else Rscript -e 'devtools::install_github("analytics-ufcg/rcongresso")'; fi
-
-RUN Rscript -e 'devtools::install_version("dplyr", version = "0.8.5", repos = "http://cran.us.r-project.org")'
 
 #Remove rcongresso files to avoid including in leggoR package
 RUN rm -rf rcongresso


### PR DESCRIPTION
## Mudanças
- Melhora ordem do build de dependências da imagem do leggoR

## Flags
- Para testar é preciso executar um `docker-compose build` na raiz do repositório