### PR TITLE
Corrige bugs no progresso de projetos do Congresso Remoto

### DIFF
--- a/R/senado_analyzer.R
+++ b/R/senado_analyzer.R
@@ -614,7 +614,9 @@ process_proposicao_senado_df <- function(proposicao_df, tramitacao_df) {
     dplyr::count(evento) %>%
     dplyr::filter(str_detect(evento, "remetida_a_sancao_promulgacao|transformada_lei"))
 
-  if (nrow(virada_de_casa) == 1) {
+  sigla_proposicao <- proposicao_df %>% dplyr::pull(sigla_tipo)
+
+  if (nrow(virada_de_casa) == 1 && sigla_proposicao != "MPV") {
     index_of_camara <-
       get_linha_virada_de_casa(proc_tram_df)
 


### PR DESCRIPTION
## Mudanças
- Cria função para corrigir detecção de eventos duplicados de apresentação de projetos numa mesma casa
- Corrige detecção da fase atual evitando filtro incorreto da fase global
- Evita ignorar eventos de MPVs após a virada de casa

Bugs que foram analisados e corrigidos:
- MPV 927/2020 tramitou no plenario do senado mas o progresso não mostra.
- MPV 983/2020 já voltou para o senado mas o progresso não mostra.
- PL 1444/2020 progresso com problemas (duas fases na camara).