### PR TITLE
Conserta erros que interferiam no mapeamento do novo id_leggo

### DIFF
--- a/R/export_data.R
+++ b/R/export_data.R
@@ -551,6 +551,7 @@ process_autores_pl <-
 process_autores_props <- function(pls_ids_filepath, export_path) {
   set.seed(123)
   pls <- readr::read_csv(pls_ids_filepath) %>%
+    dplyr::rowwise(.) %>% 
     dplyr::mutate(concat_chave_leggo = paste0(id_camara, " ", id_senado)) %>%
     dplyr::mutate(id_leggo = digest::digest(concat_chave_leggo, algo="md5", serialize=F)) %>%
     dplyr::select(-concat_chave_leggo) %>%

--- a/R/read_utils.R
+++ b/R/read_utils.R
@@ -156,7 +156,7 @@ read_props <- function(file_path) {
       id_ext =  readr::col_double(),
       numero =  readr::col_double(),
       data_apresentacao =  readr::col_datetime(format = ""),
-      id_leggo =  readr::col_double()
+      id_leggo =  readr::col_character()
     ), file_path)
 }
 


### PR DESCRIPTION
**Mudanças neste PR:**

- Conserta erro na importação dos dados de proposições, que fazia a coluna id_leggo ficar NA;
- Conserta problema na geração do csv de autores_leggo, adicionando rowwise na criação do id_leggo.