### PR TITLE
Retirar documentos duplicados nas Comissões Mistas das MPVs

### DIFF
--- a/R/atuacao.R
+++ b/R/atuacao.R
@@ -51,9 +51,7 @@ create_tabela_atuacao_camara <- function(documentos_df, autores_df, data_inicio 
                   partido,
                   uf,
                   sigla_local = status_proposicao_sigla_orgao,
-                  descricao_tipo_documento) %>% 
-    # Remove duplicação de documentos nas comissões mistas das MPVs, retirando estes documentos na Câmara
-    dplyr::filter(!stringr::str_detect(tolower(sigla_local), "mpv"))
+                  descricao_tipo_documento)
 
   peso_documentos <-
     get_peso_documentos(autores_docs)

--- a/R/atuacao.R
+++ b/R/atuacao.R
@@ -51,7 +51,9 @@ create_tabela_atuacao_camara <- function(documentos_df, autores_df, data_inicio 
                   partido,
                   uf,
                   sigla_local = status_proposicao_sigla_orgao,
-                  descricao_tipo_documento)
+                  descricao_tipo_documento) %>% 
+    # Remove duplicação de documentos nas comissões mistas das MPVs, retirando estes documentos na Câmara
+    dplyr::filter(!stringr::str_detect(tolower(sigla_local), "mpv"))
 
   peso_documentos <-
     get_peso_documentos(autores_docs)

--- a/scripts/documentos/export_coautorias.R
+++ b/scripts/documentos/export_coautorias.R
@@ -15,7 +15,9 @@
   camara_documentos <-
     camara_docs %>%
     dplyr::mutate(data = lubridate::floor_date(data_apresentacao, unit='day')) %>%
-    dplyr::left_join(props_leggo_id, by = c("id_principal", "casa"))
+    dplyr::left_join(props_leggo_id, by = c("id_principal", "casa")) %>% 
+    dplyr::rename(sigla_local = status_proposicao_sigla_orgao) %>% 
+    agoradigital::remove_atuacao_camara_comissao_mista()
 
   # Gerando dado de autorias de documentos
   if (nrow(camara_documentos) > 0) {

--- a/scripts/process_leggo_data.R
+++ b/scripts/process_leggo_data.R
@@ -137,7 +137,7 @@ process_leggo_data <- function(flag) {
       export_avulsos_iniciais(camara_docs, senado_docs, novas_emendas, output_path)
     } else if (flag == 2) {
       print("Atualizando os atuação!")
-      export_atuacao(camara_docs, camara_autores, senado_docs, senado_autores, output_path, data_inicial, peso_minimo, props_leggo_id)
+      export_atuacao(camara_docs, camara_autores, senado_docs, senado_autores, output_path, data_inicial, peso_minimo, props_leggo_id, entidades)
     } else if (flag == 3) {
       print("Atualizando nodes e edges!")
       export_nodes_edges(input_path, camara_docs, data_inicial, senado_docs, camara_autores, peso_minimo, senado_autores, props_leggo_id, output_path)


### PR DESCRIPTION
**Mudanças deste PR:**

- Remove a duplicação de documentos das Comissões Mistas nas MPVs, retirando estes documentos da atuação na câmara e deixando apenas no senado;
- Adiciona parâmetro de entidades na chamada da função export_autuacao().

Fixes #593 
