### PR TITLE
2080 Modificar tipo genérico dos documentos

### DIFF
--- a/R/atuacao.R
+++ b/R/atuacao.R
@@ -66,7 +66,8 @@ create_tabela_atuacao_camara <- function(documentos_df, autores_df, data_inicio 
                     casa,
                     id_autor,
                     tipo_generico,
-                    sigla_local) %>%
+                    sigla_local, 
+                    tipo_acao) %>%
     dplyr::summarise(peso_total_documentos = sum(peso_documento),
                      num_documentos = dplyr::n_distinct(id_documento),
                      partido = dplyr::first(partido),
@@ -150,6 +151,7 @@ create_tabela_atuacao_senado <- function(documentos_df, autores_df, data_inicio 
                       casa,
                       id_autor,
                       tipo_generico,
+                      tipo_acao,
                       sigla_local) %>%
       dplyr::summarise(peso_total_documentos = sum(peso_documento),
                        num_documentos = dplyr::n_distinct(id_documento),

--- a/R/config/environment_camara.json
+++ b/R/config/environment_camara.json
@@ -204,12 +204,11 @@
   "tipos_documentos": [
     {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 1, "tipo_acao": "Proposição"},
     {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|projeto de decreto legislativo", "peso": 2, "tipo_acao": "Proposição"},
+    {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3, "tipo_acao": "Outros"},
     {"tipo": "Requerimento", "regex": "^requerimento", "peso": 4, "tipo_acao": "Proposição"},
     {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
-    {"regex": "^projeto", "peso": 6, "tipo_acao": "Proposição"},
-    {"regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
-    {"regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
-    {"regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
-    {"regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
+    {"tipo": "Proposição", "regex": "^indicacao", "peso": 6, "tipo_acao": "Proposição"},
+    {"tipo": "Recurso", "regex": "^destaque", "peso": 7, "tipo_acao": "Recurso"},
+    {"tipo": "Recurso", "regex": "^vista|pedido de vista", "peso": 9, "tipo_acao": "Recurso"}
     ]
 }

--- a/R/config/environment_camara.json
+++ b/R/config/environment_camara.json
@@ -202,13 +202,14 @@
   ],
 
   "tipos_documentos": [
-    {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 1, "tipo_acao": "Proposição"},
-    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|projeto de decreto legislativo", "peso": 2, "tipo_acao": "Proposição"},
+    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|projeto de decreto legislativo", "peso": 1, "tipo_acao": "Proposição"},
+    {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 2, "tipo_acao": "Proposição"},
     {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3, "tipo_acao": "Outros"},
     {"tipo": "Requerimento", "regex": "^requerimento", "peso": 4, "tipo_acao": "Proposição"},
     {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
-    {"tipo": "Proposição", "regex": "^indicacao", "peso": 6, "tipo_acao": "Proposição"},
-    {"tipo": "Recurso", "regex": "^destaque", "peso": 7, "tipo_acao": "Recurso"},
-    {"tipo": "Recurso", "regex": "^vista|pedido de vista", "peso": 9, "tipo_acao": "Recurso"}
+    {"tipo": "Indicação", "regex": "^indicacao", "peso": 6, "tipo_acao": "Proposição"},
+    {"tipo": "Destaque", "regex": "^destaque", "peso": 7, "tipo_acao": "Recurso"},
+    {"tipo": "Recurso", "regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
+    {"tipo": "Vista", "regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
     ]
 }

--- a/R/config/environment_camara.json
+++ b/R/config/environment_camara.json
@@ -210,6 +210,6 @@
     {"regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
     {"regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
     {"regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
-    {"regex": "^pedido", "peso": 10, "tipo_acao": "Recurso"}
+    {"regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
     ]
 }

--- a/R/config/environment_camara.json
+++ b/R/config/environment_camara.json
@@ -202,10 +202,14 @@
   ],
 
   "tipos_documentos": [
-    {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 1},
+    {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 1, "tipo_acao": "Proposição"},
     {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|projeto de decreto legislativo", "peso": 2},
-    {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3},
-    {"tipo": "Requerimento", "regex": "^requerimento", "peso": 4},
-    {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5}
+    {"tipo": "Requerimento", "regex": "^requerimento", "peso": 4, "tipo_acao": "Proposição"},
+    {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
+    {"regex": "^projeto", "peso": 6, "tipo_acao": "Proposição"},
+    {"regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
+    {"regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
+    {"regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
+    {"regex": "^pedido", "peso": 10, "tipo_acao": "Recurso"}
     ]
 }

--- a/R/config/environment_camara.json
+++ b/R/config/environment_camara.json
@@ -203,7 +203,7 @@
 
   "tipos_documentos": [
     {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 1, "tipo_acao": "Proposição"},
-    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|projeto de decreto legislativo", "peso": 2},
+    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|projeto de decreto legislativo", "peso": 2, "tipo_acao": "Proposição"},
     {"tipo": "Requerimento", "regex": "^requerimento", "peso": 4, "tipo_acao": "Proposição"},
     {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
     {"regex": "^projeto", "peso": 6, "tipo_acao": "Proposição"},

--- a/R/config/environment_senado.json
+++ b/R/config/environment_senado.json
@@ -219,17 +219,22 @@
 
   "tipos_documentos": [
     {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|mpv|plc|pls|pl|projeto de decreto legislativo", "peso": 1},
-    {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 2},
+    {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 2, "tipo_acao": "Proposição"},
     {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3},
-    {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4},
-    {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5}
+    {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4, "tipo_acao": "Proposição"},
+    {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
+    {"regex": "^projeto", "peso": 6, "tipo_acao": "Proposição"},
+    {"regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
+    {"regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
+    {"regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
+    {"regex": "^pedido", "peso": 10, "tipo_acao": "Recurso"}
     ],
 
   "tipos_documentos_scrap": [
-    {"tipo": "Emenda", "regex": "emenda|subemenda"},
+    {"tipo": "Emenda", "regex": "emenda|subemenda", "tipo_acao": "Proposição"},
     {"tipo": "Parecer", "regex": "parecer|^complementa..o de voto|^reda..o final|^substitutivo|p\\.s|^relat(ó|o)rio|^par"},
-    {"tipo": "Requerimento", "regex": "requerimento|rqe|rqs|rqj|rra|req|rdh|rma"},
-    {"tipo": "Voto em Separado", "regex": "voto em separado"}
+    {"tipo": "Requerimento", "regex": "requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "tipo_acao": "Proposição"},
+    {"tipo": "Voto em Separado", "regex": "voto em separado", "tipo_acao": "Recurso"}
     ],
 
   "tipos_autores_scrap": [

--- a/R/config/environment_senado.json
+++ b/R/config/environment_senado.json
@@ -227,7 +227,7 @@
     {"regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
     {"regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
     {"regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
-    {"regex": "^pedido", "peso": 10, "tipo_acao": "Recurso"}
+    {"regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
     ],
 
   "tipos_documentos_scrap": [

--- a/R/config/environment_senado.json
+++ b/R/config/environment_senado.json
@@ -220,14 +220,13 @@
   "tipos_documentos": [
     {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|mpv|plc|pls|pl|projeto de decreto legislativo", "peso": 1, "tipo_acao": "Proposição"},
     {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 2, "tipo_acao": "Proposição"},
-    {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3},
+    {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3, "tipo_acao": "Outros" },
     {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4, "tipo_acao": "Proposição"},
     {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
-    {"regex": "^projeto", "peso": 6, "tipo_acao": "Proposição"},
-    {"regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
-    {"regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
-    {"regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
-    {"regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
+    {"tipo":"Proposição", "regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
+    {"tipo":"Recurso", "regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
+    {"tipo":"Recurso", "regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
+    {"tipo":"Recurso", "regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
     ],
 
   "tipos_documentos_scrap": [

--- a/R/config/environment_senado.json
+++ b/R/config/environment_senado.json
@@ -218,7 +218,7 @@
   },
 
   "tipos_documentos": [
-    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|mpv|plc|pls|pl|projeto de decreto legislativo", "peso": 1},
+    {"tipo": "Prop. Original / Apensada", "regex": "medida provis.ria|projeto de lei|projeto de lei complementar|projeto de lei de convers.o|proposta de emenda . constitui..o|mpv|plc|pls|pl|projeto de decreto legislativo", "peso": 1, "tipo_acao": "Proposição"},
     {"tipo": "Emenda", "regex": "^emenda|^subemenda", "peso": 2, "tipo_acao": "Proposição"},
     {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3},
     {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4, "tipo_acao": "Proposição"},

--- a/R/config/environment_senado.json
+++ b/R/config/environment_senado.json
@@ -223,10 +223,10 @@
     {"tipo": "Parecer", "regex": "^parecer|^complementa..o de voto|^reda..o final|^substitutivo", "peso": 3, "tipo_acao": "Outros" },
     {"tipo": "Requerimento", "regex": "^requerimento|rqe|rqs|rqj|rra|req|rdh|rma", "peso": 4, "tipo_acao": "Proposição"},
     {"tipo": "Voto em Separado", "regex": "^voto em separado", "peso": 5, "tipo_acao": "Recurso"},
-    {"tipo":"Proposição", "regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
-    {"tipo":"Recurso", "regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
+    {"tipo":"Indicação", "regex": "^indicacao", "peso": 7, "tipo_acao": "Proposição"},
+    {"tipo":"Destaque", "regex": "^destaque", "peso": 8, "tipo_acao": "Recurso"},
     {"tipo":"Recurso", "regex": "^recurso", "peso": 9, "tipo_acao": "Recurso"},
-    {"tipo":"Recurso", "regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
+    {"tipo":"Vista", "regex": "^vista|pedido de vista", "peso": 10, "tipo_acao": "Recurso"}
     ],
 
   "tipos_documentos_scrap": [

--- a/R/proposicoes.R
+++ b/R/proposicoes.R
@@ -390,8 +390,8 @@ add_tipo_evento_documento <- function(docs_data, documentos_scrap = F) {
         fuzzyjoin::regex_left_join(senado_env$tipos_documentos, by = c(descricao_tipo_texto = "regex"), ignore_case = T) %>%
         dplyr::mutate(tipo = dplyr::if_else(is.na(tipo), "Outros", tipo),  # default para tipos não agrupados
                       tipo = dplyr::if_else(str_detect(tipo, "P.S"), "Outros", tipo), # Corrige casos de falsos positivos em matérias legislativas.
-                      peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso)),
-                      tipo_acao = dplyr::if_else(is.na(tipo_acao), "Outros", tipo_acao)) %>% # Atribui peso default
+                      peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso)), # Atribui peso default
+                      tipo_acao = dplyr::if_else(is.na(tipo_acao), "Outros", tipo_acao)) %>% 
         # Remove casos duplicados usando o peso do regex na ordem de precedência
         dplyr::group_by(id_principal, casa, id_documento, id_autor) %>%
         dplyr::mutate(max_peso = max(peso)) %>%
@@ -566,7 +566,8 @@ classifica_tipo_documento_autorias <- function(docs) {
     filter(casa == "camara") %>%
     fuzzyjoin::regex_left_join(camara_env$tipos_documentos, by = c(descricao_tipo_documento = "regex"), ignore_case = T) %>%
     dplyr::mutate(tipo = dplyr::if_else(is.na(tipo), "Outros", tipo),
-                  peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso))) %>%
+                  peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso)),
+                  tipo_acao = dplyr::if_else(is.na(tipo_acao), "Outros", tipo_acao)) %>%
     dplyr::group_by(id_principal, casa, id_documento, id_autor) %>%
     mutate(max_peso = max(peso)) %>%
     ungroup() %>%
@@ -578,7 +579,8 @@ classifica_tipo_documento_autorias <- function(docs) {
     fuzzyjoin::regex_left_join(senado_env$tipos_documentos, by = c(tipo_documento_ext = "regex"), ignore_case = T) %>%
     dplyr::mutate(tipo = dplyr::if_else(is.na(tipo), "Outros", tipo), # default para tipos não agrupados
                   tipo = dplyr::if_else(str_detect(tipo, "P.S"), "Outros", tipo), # Corrige casos de falsos positivos em matérias legislativas.
-                  peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso))) %>% # Atribui peso default
+                  peso = dplyr::if_else(is.na(peso), 0, as.numeric(peso)), # Atribui peso default
+                  tipo_acao = dplyr::if_else(is.na(tipo_acao), "Outros", tipo_acao)) %>% 
     # Remove casos duplicados usando o peso do regex na ordem de precedência
     dplyr::group_by(id_principal, casa, id_documento, id_autor) %>%
     mutate(max_peso = max(peso)) %>%

--- a/scripts/documentos/export_atuacao.R
+++ b/scripts/documentos/export_atuacao.R
@@ -7,15 +7,16 @@
 #' @param data_inicio data a partir da qual se considerará os documentos
 #' @param peso_minimo limiar para peso dos documentos
 #' @param output_path pasta para onde exportar os dados
+#'  
 export_atuacao <- function(camara_docs, camara_autores, senado_docs, senado_autores, output_path, data_inicio, peso_minimo, props_leggo_id, entidades) {
   print(paste("Gerando tabela de atuação a partir de dados atualizados de documentos e autores..."))
 
-  atuacao_camara <- agoradigital::create_tabela_atuacao_camara(camara_docs, camara_autores, data_inicio = data_inicio, limiar = peso_minimo) %>%
-    select(id_ext, casa, id_autor, tipo_autor, tipo_generico, sigla_local, peso_total_documentos, num_documentos, partido, uf, nome_autor, is_important) %>%
+atuacao_camara <- agoradigital::create_tabela_atuacao_camara(camara_docs, camara_autores, data_inicio = data_inicio, limiar = peso_minimo) %>%
+    select(id_ext, casa, id_autor, tipo_autor, tipo_generico, sigla_local, peso_total_documentos, num_documentos, partido, uf, nome_autor, is_important, tipo_acao) %>%
     agoradigital::remove_atuacao_camara_comissao_mista()
 
   atuacao_senado <- agoradigital::create_tabela_atuacao_senado(senado_docs, senado_autores, data_inicio = data_inicio, limiar = peso_minimo) %>%
-    select(id_ext, casa, id_autor, tipo_autor, tipo_generico, sigla_local, peso_total_documentos, num_documentos, partido, uf, nome_autor, is_important)
+    select(id_ext, casa, id_autor, tipo_autor, tipo_generico, sigla_local, peso_total_documentos, num_documentos, partido, uf, nome_autor, is_important, tipo_acao)
 
   .PARTIDOS_OPOSICAO <-
     c("PT", "PSOL", "PSB", "PCdoB", "PDT", "REDE")
@@ -44,12 +45,11 @@ export_atuacao <- function(camara_docs, camara_autores, senado_docs, senado_auto
                        by = c("id_autor_parlametria")) %>%
       dplyr::select(id_leggo, id_autor_parlametria, id_ext, casa, id_autor, nome_autor = nome, partido, uf,
                     tipo_autor, casa_autor, tipo_generico, sigla_local,
-                    peso_total_documentos, num_documentos, is_important, bancada)
+                    peso_total_documentos, num_documentos, is_important, bancada, tipo_acao)
   } else {
     atuacao_df <- tibble::tribble(~id_leggo, ~id_autor_parlametria, ~id_ext, ~casa, ~id_autor, ~nome_autor, ~partido, ~uf,
                                   ~tipo_autor, ~casa_autor, ~tipo_generico,
-                                 ~sigla_local, ~peso_total_documentos, ~num_documentos, ~is_important, ~bancada)
+                                 ~sigla_local, ~peso_total_documentos, ~num_documentos, ~is_important, ~bancada, ~tipo_acao)
   }
-
   readr::write_csv(atuacao_df, paste0(output_path, '/atuacao.csv'), na = "")
 }

--- a/scripts/documentos/export_coautorias.R
+++ b/scripts/documentos/export_coautorias.R
@@ -43,7 +43,7 @@
                                  ~bancada.y)
     autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~tipo_documento_ext,
                                 ~id_autor, ~data, ~url_inteiro_teor, ~id_leggo, ~peso_autor_documento, ~casa_autor, ~nome_eleitoral,
-                                ~autores)
+                                ~autores, ~tipo_acao)
   }
 
   readr::write_csv(coautorias, paste0(output_path, '/camara/coautorias.csv'))
@@ -95,7 +95,7 @@
                                  ~casa_autor.y, ~bancada.y)
     autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, tipo_documento_ex,
                                 ~id_autor, ~data, ~url_inteiro_teor, ~id_leggo, ~peso_autor_documento, ~casa_autor, ~nome_eleitoral,
-                                ~autores)
+                                ~autores, ~tipo_acao)
   }
 
   readr::write_csv(coautorias, paste0(output_path, '/senado/coautorias.csv'))
@@ -166,7 +166,7 @@ export_nodes_edges <- function(input_path, camara_docs, data_inicial, senado_doc
     edges <- tibble::tribble(~id_leggo, ~source, ~target, ~value)
     autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~id_autor,
                                 ~data, ~url_inteiro_teor, ~id_leggo, ~peso_autor_documento, ~casa_autor,
-                                ~nome_eleitoral, ~autores, ~id_autor_parlametria, ~tipo_documento)
+                                ~nome_eleitoral, ~autores, ~id_autor_parlametria, ~tipo_documento, ~tipo_acao)
   }
 
   readr::write_csv(nodes , paste0(output_path, '/coautorias_nodes.csv'), na = "")

--- a/scripts/documentos/export_coautorias.R
+++ b/scripts/documentos/export_coautorias.R
@@ -43,7 +43,7 @@
                                  ~bancada.y)
     autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, ~tipo_documento_ext,
                                 ~id_autor, ~data, ~url_inteiro_teor, ~id_leggo, ~peso_autor_documento, ~casa_autor, ~nome_eleitoral,
-                                ~autores, ~tipo_acao)
+                                ~autores)
   }
 
   readr::write_csv(coautorias, paste0(output_path, '/camara/coautorias.csv'))
@@ -95,7 +95,7 @@
                                  ~casa_autor.y, ~bancada.y)
     autorias <- tibble::tribble(~id_principal, ~casa, ~id_documento, ~descricao_tipo_documento, tipo_documento_ex,
                                 ~id_autor, ~data, ~url_inteiro_teor, ~id_leggo, ~peso_autor_documento, ~casa_autor, ~nome_eleitoral,
-                                ~autores, ~tipo_acao)
+                                ~autores)
   }
 
   readr::write_csv(coautorias, paste0(output_path, '/senado/coautorias.csv'))

--- a/scripts/process_leggo_data.R
+++ b/scripts/process_leggo_data.R
@@ -5,8 +5,6 @@ source(here::here("scripts/documentos/export_atuacao.R"))
 source(here::here("scripts/documentos/export_coautorias.R"))
 source(here::here("scripts/documentos/export_emendas.R"))
 
-# input_path = '~/leggo_data'
-
 .HELP <- "
 Rscript process_leggo_data.R -i <input_path> -o <output_path> -d <data_inicial_documentos> -p <peso_minimo_arestas> -f <flag>
 "
@@ -103,7 +101,6 @@ process_leggo_data <- function(flag) {
     ## Install local repository R package version
     devtools::install(upgrade = "never")
     
-    
     # Read current data csvs
     camara_docs <- agoradigital::read_current_docs_camara(paste0(input_path, "/camara/documentos.csv")) %>%
       dplyr::mutate(casa = as.character(casa))
@@ -130,7 +127,6 @@ process_leggo_data <- function(flag) {
       agoradigital::read_props(paste0(input_path, "/proposicoes.csv")) %>%
       dplyr::select(id_leggo, id_principal = id_ext, casa)
     
-    # entidades_path = '~/leggo_data/entidades.csv'
     entidades <- readr::read_csv(entidades_path)
 
     if (flag == 1) {

--- a/scripts/process_leggo_data.R
+++ b/scripts/process_leggo_data.R
@@ -5,6 +5,8 @@ source(here::here("scripts/documentos/export_atuacao.R"))
 source(here::here("scripts/documentos/export_coautorias.R"))
 source(here::here("scripts/documentos/export_emendas.R"))
 
+input_path = '~/leggo_data'
+
 .HELP <- "
 Rscript process_leggo_data.R -i <input_path> -o <output_path> -d <data_inicial_documentos> -p <peso_minimo_arestas> -f <flag>
 "
@@ -100,7 +102,8 @@ process_leggo_data <- function(flag) {
   } else {
     ## Install local repository R package version
     devtools::install(upgrade = "never")
-
+    
+    
     # Read current data csvs
     camara_docs <- agoradigital::read_current_docs_camara(paste0(input_path, "/camara/documentos.csv")) %>%
       dplyr::mutate(casa = as.character(casa))
@@ -126,7 +129,8 @@ process_leggo_data <- function(flag) {
     props_leggo_id <-
       agoradigital::read_props(paste0(input_path, "/proposicoes.csv")) %>%
       dplyr::select(id_leggo, id_principal = id_ext, casa)
-
+    
+    entidades_path = '~/leggo_data/entidades.csv'
     entidades <- readr::read_csv(entidades_path)
 
     if (flag == 1) {

--- a/scripts/process_leggo_data.R
+++ b/scripts/process_leggo_data.R
@@ -5,7 +5,7 @@ source(here::here("scripts/documentos/export_atuacao.R"))
 source(here::here("scripts/documentos/export_coautorias.R"))
 source(here::here("scripts/documentos/export_emendas.R"))
 
-input_path = '~/leggo_data'
+# input_path = '~/leggo_data'
 
 .HELP <- "
 Rscript process_leggo_data.R -i <input_path> -o <output_path> -d <data_inicial_documentos> -p <peso_minimo_arestas> -f <flag>
@@ -130,7 +130,7 @@ process_leggo_data <- function(flag) {
       agoradigital::read_props(paste0(input_path, "/proposicoes.csv")) %>%
       dplyr::select(id_leggo, id_principal = id_ext, casa)
     
-    entidades_path = '~/leggo_data/entidades.csv'
+    # entidades_path = '~/leggo_data/entidades.csv'
     entidades <- readr::read_csv(entidades_path)
 
     if (flag == 1) {

--- a/tests/testthat/test-tipo-documento.R
+++ b/tests/testthat/test-tipo-documento.R
@@ -120,14 +120,13 @@ setup <- function(){
   docs_outros <<- tibble::tibble(descricao_tipo_documento = c("Ata",
                                                   "Autógrafo",
                                                   "Mensagem",
-                                                  "Reclamação",
-                                                  "Recurso"),
-                                 id_principal = rep(1, 5),
-                                 id_autor = rep(1, 5),
-                                 id_documento = 1:5,
-                                 casa = rep('camara',5))
+                                                  "Reclamação"),
+                                 id_principal = rep(1, 4),
+                                 id_autor = rep(1, 4),
+                                 id_documento = 1:4,
+                                 casa = rep('camara',4))
 
-  docs_outros_gt <<- dplyr::mutate(docs_outros, tipo = rep(regex_documento_outros,5), tipo_acao = rep(regex_documento_outros_acao,5))
+  docs_outros_gt <<- dplyr::mutate(docs_outros, tipo = rep(regex_documento_outros,4), tipo_acao = rep(regex_documento_outros_acao,4))
 
   return(TRUE)
 }

--- a/tests/testthat/test-tipo-documento.R
+++ b/tests/testthat/test-tipo-documento.R
@@ -3,6 +3,14 @@ context("Tipo de Documento")
 # Setup
 setup <- function(){
   tipos_documentos <- c("Emenda","Prop. Original / Apensada","Parecer","Requerimento","Voto em Separado","Outros")
+  tipos_acao <- c("Proposição", "Recurso", "Outros")
+  regex_documento_emenda_acao <<- tipos_acao[1]
+  regex_documento_proposicao_acao <<-tipos_acao[1]
+  regex_documento_requerimento_acao <<-tipos_acao[1]
+  regex_documento_voto_em_separado_acao <<-tipos_acao[2]
+  regex_documento_outros_acao <<-  tipos_acao[3]
+  regex_documento_parecer_acao <<- tipos_acao[3]
+  
   regex_documento_emenda <<- tipos_documentos[1]
   regex_documento_proposicao <<- tipos_documentos[2]
   regex_documento_parecer <<- tipos_documentos[3]
@@ -29,7 +37,7 @@ setup <- function(){
                                   id_documento = 1:14,
                                   casa = rep('camara',14))
 
-  docs_emendas_gt <<- dplyr::mutate(docs_emendas, tipo = rep(regex_documento_emenda,14))
+  docs_emendas_gt <<- dplyr::mutate(docs_emendas, tipo = rep(regex_documento_emenda,14), tipo_acao = rep(regex_documento_emenda_acao,14))
 
   docs_proposicoes <<- tibble::tibble(descricao_tipo_documento = c("Medida provisoria",
                                                           "Medida provisória",
@@ -44,7 +52,7 @@ setup <- function(){
                                       id_documento = 9:16,
                                       casa = rep('camara',8))
 
-  docs_proposicoes_gt <<- dplyr::mutate(docs_proposicoes, tipo = rep(regex_documento_proposicao,8))
+  docs_proposicoes_gt <<- dplyr::mutate(docs_proposicoes, tipo = rep(regex_documento_proposicao,8), tipo_acao= rep(regex_documento_proposicao_acao,8))
 
   docs_pareceres <<- tibble::tibble(descricao_tipo_documento = c("Parecer às Emendas apresentadas ao substitutivo do relator",
                                                      "Parecer às Emendas de plenário",
@@ -68,7 +76,7 @@ setup <- function(){
                                     id_documento = 18:34,
                                     casa = rep('camara',17))
 
-  docs_pareceres_gt <<- dplyr::mutate(docs_pareceres, tipo = rep(regex_documento_parecer,17))
+  docs_pareceres_gt <<- dplyr::mutate(docs_pareceres, tipo = rep(regex_documento_parecer,17), tipo_acao = rep(regex_documento_parecer_acao,17))
 
   docs_requerimentos <<- tibble::tibble(descricao_tipo_documento = c("Requerimento",
                                                          "Requerimento de apensação",
@@ -99,7 +107,7 @@ setup <- function(){
                                         id_documento = 1:24,
                                         casa = rep('camara',24))
 
-  docs_requerimentos_gt <<- dplyr::mutate(docs_requerimentos, tipo = rep(regex_documento_requerimento,24))
+  docs_requerimentos_gt <<- dplyr::mutate(docs_requerimentos, tipo = rep(regex_documento_requerimento,24), tipo_acao= rep(regex_documento_requerimento_acao,24))
 
   docs_voto_em_separado <<- tibble::tibble(descricao_tipo_documento = c("Voto em Separado"),
                                            id_principal = 1,
@@ -107,7 +115,7 @@ setup <- function(){
                                            id_documento = 1,
                                            casa = c('camara'))
 
-  docs_voto_em_separado_gt <<- dplyr::mutate(docs_voto_em_separado, tipo = c(regex_documento_voto_em_separado))
+  docs_voto_em_separado_gt <<- dplyr::mutate(docs_voto_em_separado, tipo = c(regex_documento_voto_em_separado), tipo_acao = c(regex_documento_voto_em_separado_acao))
 
   docs_outros <<- tibble::tibble(descricao_tipo_documento = c("Ata",
                                                   "Autógrafo",
@@ -119,7 +127,7 @@ setup <- function(){
                                  id_documento = 1:5,
                                  casa = rep('camara',5))
 
-  docs_outros_gt <<- dplyr::mutate(docs_outros, tipo = rep(regex_documento_outros,5))
+  docs_outros_gt <<- dplyr::mutate(docs_outros, tipo = rep(regex_documento_outros,5), tipo_acao = rep(regex_documento_outros_acao,5))
 
   return(TRUE)
 }
@@ -130,7 +138,7 @@ check_api <- function(){
 
 test <- function(){
   test_that("Regex do tipo do documento funciona para as emendas", {
-    expect_equal(add_tipo_evento_documento(docs_emendas),docs_emendas_gt)
+    expect_equal(add_tipo_evento_documento(docs_emendas), docs_emendas_gt)
   })
 
   test_that("Regex do tipo do documento funciona para as proposicoes", {


### PR DESCRIPTION
## Mudanças
- Adiciona nova coluna(tipo_acao) nos csvs de atuação e autorias, mantendo os tipos de documentos antigos. 
- Modifica função de adicionar tipo de documento, e classificar o tipo de documentos para autorias a fim de adicionar o tipo de ação e agrupar em Outros os tipos não utilizados.
- Modifica o json da camara e do senado para adicionar novos tipos de ação.
