### PR TITLE
Adiciona CMO ao regex que atribui id_autor aos documentos

### DIFF
--- a/R/config/environment_congresso.json
+++ b/R/config/environment_congresso.json
@@ -146,7 +146,8 @@
     {"id_entidade": 14, "regex": "CT - Modernização da Lei de Licitações e Contratos"},
     {"id_entidade": 16, "regex": "^Câmara dos Deputados$"},
     {"id_entidade": 78, "regex": "Senado Federal -"},
-    {"id_entidade": 17, "regex": "Programa e-Cidadania"}
+    {"id_entidade": 17, "regex": "Programa e-Cidadania"},
+    {"id_entidade": 18, "regex": "Comissão Mista de Planos, Orçamentos Públicos e Fiscalização"}
   ],
   
   "legislaturas":[


### PR DESCRIPTION
**Mudanças deste PR:**

- Cria mapeamento de Comissão Mista de Planos, Orçamentos Públicos e Fiscalização no regex que adiciona id_autor.

 
Resolve o problema do id_autor = '3NA'. Isso acontecia para a proposição cujo id_senado é 99699 e como autor a Comissão Mista de Planos, Orçamentos Públicos e Fiscalização, entidade que não tínhamos mapeado ainda.