### PR TITLE
Adiciona critério 'mais comentadas no twitter'

### DIFF
--- a/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
+++ b/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
@@ -26,9 +26,10 @@ library(tidyverse)
     )
     
     proposicoes <- RCurl::getURL(url) %>%
-      jsonlite::fromJSON() 
-    # %>%
-      # select(id_leggo = id_proposicao_leggo, num_tweets)
+      jsonlite::fromJSON() %>% 
+      select(id_leggo = id_proposicao_leggo, num_parlamentares_tweets) %>% 
+      mutate(num_parlamentares_tweets = as.numeric(num_parlamentares_tweets)) %>% 
+      filter(num_parlamentares_tweets > 1)
     
     return(proposicoes)
     

--- a/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
+++ b/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
@@ -1,0 +1,53 @@
+library(tidyverse)
+
+#' @title Retorna o critério de proposições mais comentadas no twitter
+#' @description Retorna o critério de proposições mais comentadas no twitter
+#' de acordo com uma agenda e intervalo de datas.
+#' @param interesse Interesse alvo
+#' @param data_inicial Data inicial
+#' @param data_final Data final
+#' @return Dataframe contendo as proposições mais comentadas de um interesse.
+.fetch_proposicoes_mais_comentadas_twitter <-
+  function(interesse = "leggo",
+           data_inicial = "2000-01-01",
+           data_final = Sys.Date()) {
+    print(paste0(
+      "Baixando proposições mais comentadas da agenda ",
+      interesse,
+      "..."
+    ))
+    url <- paste0(
+      "http://localhost:5001/api/proposicoes/mais-comentadas?interesse=",
+      interesse,
+      "&data_inicial=",
+      data_inicial,
+      "&data_final=",
+      data_final
+    )
+    
+    proposicoes <- RCurl::getURL(url) %>%
+      jsonlite::fromJSON() %>%
+      select(id_leggo = id_proposicao_leggo, num_tweets)
+    
+    return(proposicoes)
+    
+  }
+
+#' @title Retorna o critério de proposições mais comentadas no twitter
+#' @description Retorna o critério de proposições mais comentadas no twitter
+#' em um intervalo de datas para todas as agendas.
+#' @param data_inicial Data inicial
+#' @param data_final Data final
+#' @return Dataframe contendo as proposições mais comentadas de todos os interesses.
+fetch_proposicoes_mais_comentadas_twitter <-
+  function(data_inicial = "2000-01-01",
+           data_final = Sys.Date(),
+           interesses = c("leggo", "congresso-remoto", "transparencia-e-integridade")) {
+    df <-
+      purrr::map_df(
+        interesses,
+        ~ .fetch_proposicoes_mais_comentadas_twitter(.x, data_inicial, data_final)
+      )
+    
+    return(df)
+  }

--- a/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
+++ b/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
@@ -17,7 +17,7 @@ library(tidyverse)
       "..."
     ))
     url <- paste0(
-      "http://localhost:5001/api/proposicoes/mais-comentadas?interesse=",
+      "https://leggo-twitter-validacao.herokuapp.com/api/proposicoes/mais-comentadas?interesse=",
       interesse,
       "&data_inicial=",
       data_inicial,

--- a/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
+++ b/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
@@ -26,8 +26,9 @@ library(tidyverse)
     )
     
     proposicoes <- RCurl::getURL(url) %>%
-      jsonlite::fromJSON() %>%
-      select(id_leggo = id_proposicao_leggo, num_tweets)
+      jsonlite::fromJSON() 
+    # %>%
+      # select(id_leggo = id_proposicao_leggo, num_tweets)
     
     return(proposicoes)
     

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -9,8 +9,15 @@ process_proposicoes_destaques <- function(
 
   source(here::here("scripts/proposicoes/destaques/process_criterio_aprovada_em_uma_casa.R"))
   source(here::here("scripts/proposicoes/destaques/process_criterio_parecer_aprovado_comissao.R"))
+  source(here::here("scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R"))
 
-  interesses <- read_csv(interesses_datapath) %>%
+  interesses <- read_csv(interesses_datapath)
+  
+  interesses_agendas <- interesses %>% 
+    distinct(interesse) %>% 
+    pull()
+    
+  interesses <- interesses %>%
     group_by(id_leggo) %>%
     summarise(agendas = paste(interesse, collapse = ";")) %>%
     ungroup()
@@ -33,6 +40,9 @@ process_proposicoes_destaques <- function(
                                                  tramitacoes_datapath) %>%
     mutate(criterio_parecer_aprovado_comissao = T) %>%
     select(id_leggo, id_ext, casa, criterio_parecer_aprovado_comissao, comissoes_aprovadas)
+  
+  proposicoes_criterio_mais_comentadas_twitter <- 
+    fetch_proposicoes_mais_comentadas_twitter(interesses = interesses_agendas)
 
   proposicoes_destaques <- proposicoes %>%
     left_join(proposicoes_criterio_aprovada_em_uma_casa,

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -43,9 +43,7 @@ process_proposicoes_destaques <- function(
   
   proposicoes_criterio_mais_comentadas_twitter <- 
     fetch_proposicoes_mais_comentadas_twitter(interesses = interesses_agendas) %>% 
-    select(id_leggo = id_proposicao_leggo, num_tweets) %>% 
-    mutate(criterio_mais_comentadas_twitter = num_tweets > 1) %>%
-    filter(criterio_mais_comentadas_twitter) %>% 
+    mutate(criterio_mais_comentadas_twitter = T) %>%
     distinct()
 
   proposicoes_destaques <- proposicoes %>%

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -42,7 +42,20 @@ process_proposicoes_destaques <- function(
     select(id_leggo, id_ext, casa, criterio_parecer_aprovado_comissao, comissoes_aprovadas)
   
   proposicoes_criterio_mais_comentadas_twitter <- 
-    fetch_proposicoes_mais_comentadas_twitter(interesses = interesses_agendas)
+    fetch_proposicoes_mais_comentadas_twitter(interesses = interesses_agendas) %>% 
+    mutate(num_tweets = as.numeric(num_tweets)) %>% 
+    distinct()
+  
+  quartil_3 <- proposicoes_criterio_mais_comentadas_twitter %>% 
+    pull(num_tweets) %>% 
+    quantile() %>% 
+    getElement("75%")
+  
+  a = proposicoes_criterio_mais_comentadas_twitter %>% 
+    filter(num_tweets >= quartil_3)
+    
+    group_by(id_leggo) %>% 
+    mutate(ranker = quantile(num_tweets))
 
   proposicoes_destaques <- proposicoes %>%
     left_join(proposicoes_criterio_aprovada_em_uma_casa,

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -43,27 +43,21 @@ process_proposicoes_destaques <- function(
   
   proposicoes_criterio_mais_comentadas_twitter <- 
     fetch_proposicoes_mais_comentadas_twitter(interesses = interesses_agendas) %>% 
-    mutate(num_tweets = as.numeric(num_tweets)) %>% 
+    select(id_leggo = id_proposicao_leggo, num_tweets) %>% 
+    mutate(criterio_mais_comentadas_twitter = num_tweets > 1) %>%
+    filter(criterio_mais_comentadas_twitter) %>% 
     distinct()
-  
-  quartil_3 <- proposicoes_criterio_mais_comentadas_twitter %>% 
-    pull(num_tweets) %>% 
-    quantile() %>% 
-    getElement("75%")
-  
-  a = proposicoes_criterio_mais_comentadas_twitter %>% 
-    filter(num_tweets >= quartil_3)
-    
-    group_by(id_leggo) %>% 
-    mutate(ranker = quantile(num_tweets))
 
   proposicoes_destaques <- proposicoes %>%
     left_join(proposicoes_criterio_aprovada_em_uma_casa,
                by = c("id_leggo")) %>%
     left_join(proposicoes_criterio_parecer_aprovado_comissao,
               by = c("id_leggo", "id_ext", "casa")) %>%
+    left_join(proposicoes_criterio_mais_comentadas_twitter,
+              by = c("id_leggo")) %>% 
     mutate(criterio_aprovada_em_uma_casa = !is.na(criterio_aprovada_em_uma_casa),
-           criterio_parecer_aprovado_comissao = !is.na(criterio_parecer_aprovado_comissao)) %>%
+           criterio_parecer_aprovado_comissao = !is.na(criterio_parecer_aprovado_comissao),
+           criterio_mais_comentadas_twitter = !is.na(criterio_mais_comentadas_twitter)) %>%
     left_join(interesses, by = c("id_leggo"))
 
   return(proposicoes_destaques)


### PR DESCRIPTION
**Mudanças neste PR:**

- Adiciona scripts que baixam os números de tweets por proposição;
- Adiciona processamento que filtra as proposições que possuem mais de um tweet associado.

**OBS:** Revisar o PR #[34](https://github.com/parlametria/leggo-twitter/pull/34) e modificar o endereço da API para o local. (atualmente está a de validação - ainda não foi deploy)