### PR TITLE
Refatora critério de avanço nas comissões

### DIFF
--- a/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
+++ b/scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R
@@ -24,15 +24,22 @@ library(tidyverse)
       "&data_final=",
       data_final
     )
-    
+
     proposicoes <- RCurl::getURL(url) %>%
-      jsonlite::fromJSON() %>% 
-      select(id_leggo = id_proposicao_leggo, num_parlamentares_tweets) %>% 
-      mutate(num_parlamentares_tweets = as.numeric(num_parlamentares_tweets)) %>% 
-      filter(num_parlamentares_tweets > 1)
-    
-    return(proposicoes)
-    
+      jsonlite::fromJSON()
+
+    if (!is.null(nrow(proposicoes))) {
+      proposicoes <- proposicoes %>%
+        select(id_leggo = id_proposicao_leggo, num_parlamentares_tweets) %>%
+        mutate(num_parlamentares_tweets = as.numeric(num_parlamentares_tweets)) %>%
+        filter(num_parlamentares_tweets > 1)
+
+      return(proposicoes)
+
+    } else {
+      return(tibble())
+    }
+
   }
 
 #' @title Retorna o critério de proposições mais comentadas no twitter
@@ -50,6 +57,6 @@ fetch_proposicoes_mais_comentadas_twitter <-
         interesses,
         ~ .fetch_proposicoes_mais_comentadas_twitter(.x, data_inicial, data_final)
       )
-    
+
     return(df)
   }

--- a/scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R
+++ b/scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R
@@ -1,32 +1,46 @@
 library(tidyverse)
 library(here)
+library(lubridate)
 
-#' @title Processa critério de parecer aprovado em comissão.
-#' @description Processa o critério que retorna informações de proposições que tiveram algum parecer
-#' aprovado em uma comissão.
-#' @param tramitacoes_datapath Caminho para o CSV de tramitações.
-#' @return Dataframe com informações de proposições com parecer aprovado em comissões.
+#' @title Verifica se proposições passaram pela CCJ.
+#' @description Processa verificação das proposições que passaram ou não na CCJ.
+#' @param proposicoes_df Dataframe de proposições.
+#' @param tramitacoes_df Dataframe de tramitações.
+#' @return Dataframe de proposicoes_df com coluna a mais indicando se a proposição passou ou não pela CCJ.
 #' @examples
-#' process_criterio_avancou_comissoes()
-process_criterio_avancou_comissoes <- function(
-  proposicoes_datapath = here::here("leggo_data/proposicoes.csv"),
-  tramitacoes_datapath = here::here("leggo_data/trams.csv")) {
-  # tramitacoes <- read_csv("~/leggo_data/trams.csv")
-  # proposicoes <- read_csv("~/leggo_data/proposicoes.csv")
-  tramitacoes <- read_csv(tramitacoes_datapath,
-                          col_types = cols(data_audiencia = col_datetime(),
-                                           data = col_datetime(),
-                                           sequencia = col_integer(),
-                                           .default = col_character()))
+#' .verifica_local_ccj(proposicoes_df, tramitacoes_df)
+.verifica_local_ccj <- function(proposicoes_df, tramitacoes_df) {
+  tram_ccj <- tramitacoes_df %>%
+    dplyr::filter(sigla_local %in% c("CCJ", "CCJC")) %>%
+    dplyr::filter(!is.na(evento)) %>%
 
-  proposicoes <- read_csv(proposicoes_datapath,
-                          col_types = cols(id_ext = col_character())) %>%
-    select(id_ext, casa, id_leggo)
+    group_by(id_ext, casa, sigla_local) %>%
+    summarise(eventos = paste(evento, collapse = ";")) %>%
+    ungroup() %>%
 
+    dplyr::filter(!str_detect(eventos, "parecer_pela_rejeicao"))
+
+  proposicoes_ccj <- proposicoes_df %>%
+    left_join(tram_ccj, by = c("id_ext", "casa")) %>%
+    mutate(ccj = !is.na(sigla_local)) %>%
+    select(id_ext, casa, id_leggo, ccj)
+
+  return(proposicoes_ccj)
+}
+
+#' @title Verifica se proposições tiveram parecer aprovado em alguma comissão.
+#' @description Processa verificação das proposições que tiveram ou não parecer aprovado em alguma comissão.
+#' @param proposicoes_df Dataframe de proposições.
+#' @param tramitacoes_df Dataframe de tramitações.
+#' @return Dataframe de proposicoes_df com coluna a mais indicando se a proposição teve parecer aprovado em alguma
+#' comissão ou não.
+#' @examples
+#' .verifica_aprovacao_parecer(proposicoes_df, tramitacoes_df)
+.verifica_aprovacao_parecer <- function(proposicoes_df, tramitacoes_df) {
   ## Lista de locais que não são comissões
   locais_filtro <- c("mesa", "ata-plen", "plen", "seadi")
 
-  eventos_agrupados <- tramitacoes %>%
+  eventos_agrupados <- tramitacoes_df %>%
     dplyr::filter(!is.na(evento)) %>%
     dplyr::filter(!tolower(sigla_local) %in% locais_filtro) %>%
     group_by(id_ext, casa, sigla_local) %>%
@@ -42,10 +56,63 @@ process_criterio_avancou_comissoes <- function(
     summarise(comissoes_aprovadas = paste(sigla_local, collapse = ";")) %>%
     ungroup()
 
-  proposicoes_alt <- proposicoes_aprovadas %>%
-    left_join(proposicoes, by = c("id_ext", "casa")) %>%
-    distinct() %>%
-    select(id_leggo, id_ext, casa, comissoes_aprovadas)
+  proposicoes_parecer_aprovado <- proposicoes_df %>%
+    left_join(proposicoes_aprovadas, by = c("id_ext", "casa")) %>%
+    mutate(parecer_aprovado = !is.na(comissoes_aprovadas)) %>%
+    select(id_ext, casa, id_leggo, parecer_aprovado)
+
+  return(proposicoes_parecer_aprovado)
+}
+
+#' @title Processa critério de parecer aprovado em comissão.
+#' @description Processa o critério que retorna informações de proposições que tiveram algum parecer
+#' aprovado em uma comissão.
+#' @param tramitacoes_datapath Caminho para o CSV de tramitações.
+#' @return Dataframe com informações de proposições com parecer aprovado em comissões.
+#' @examples
+#' process_criterio_avancou_comissoes()
+process_criterio_avancou_comissoes <- function(
+  proposicoes_datapath = here::here("leggo_data/proposicoes.csv"),
+  tramitacoes_datapath = here::here("leggo_data/trams.csv")) {
+
+  tramitacoes <- read_csv(tramitacoes_datapath,
+                          col_types = cols(data_audiencia = col_datetime(),
+                                           data = col_datetime(),
+                                           sequencia = col_integer(),
+                                           .default = col_character()))
+
+  ano_atual <- lubridate::year(Sys.time())
+  ## Filtra eventos dos últimos 4 anos
+  tramitacoes <- tramitacoes %>%
+    dplyr::filter(lubridate::year(data) > (ano_atual - 4))
+
+  proposicoes <- read_csv(proposicoes_datapath,
+                          col_types = cols(id_ext = col_character())) %>%
+    select(id_ext, casa, id_leggo)
+
+  proposicoes_destaque_camara <- proposicoes %>%
+    filter(casa == "camara") %>%
+    .verifica_local_ccj(tramitacoes)
+
+  proposicoes_destaque_senado <- proposicoes %>%
+    filter(casa == "senado") %>%
+    .verifica_aprovacao_parecer(tramitacoes)
+
+  proposicoes_merge <- proposicoes_destaque_camara %>%
+    bind_rows(proposicoes_destaque_senado) %>%
+    select(id_leggo, id_ext, casa, ccj_camara = ccj, parecer_aprovado_comissao = parecer_aprovado) %>%
+    distinct(id_leggo, id_ext, casa, .keep_all = T)
+
+  proposicoes_alt <- proposicoes_merge %>%
+    mutate_at(.funs = list(~replace_na(., FALSE)),
+              .vars = vars(ccj_camara, parecer_aprovado_comissao)) %>%
+    group_by(id_leggo) %>%
+    summarise(ccj_camara = sum(ccj_camara),
+              parecer_aprovado_comissao = max(parecer_aprovado_comissao)) %>%
+    ungroup() %>%
+    distinct(id_leggo, .keep_all = T) %>%
+    mutate(ccj_camara = as.logical(ccj_camara),
+           parecer_aprovado_comissao = as.logical(parecer_aprovado_comissao))
 
   return(proposicoes_alt)
 }

--- a/scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R
+++ b/scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R
@@ -81,10 +81,12 @@ process_criterio_avancou_comissoes <- function(
                                            sequencia = col_integer(),
                                            .default = col_character()))
 
-  ano_atual <- lubridate::year(Sys.time())
   ## Filtra eventos dos últimos 4 anos
+  hoje <- Sys.time()
   tramitacoes <- tramitacoes %>%
-    dplyr::filter(lubridate::year(data) > (ano_atual - 4))
+    mutate(idade = lubridate::interval(data, hoje) %>%
+             as.numeric('years')) %>%
+    dplyr::filter(idade <= 4)
 
   proposicoes <- read_csv(proposicoes_datapath,
                           col_types = cols(id_ext = col_character())) %>%

--- a/scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R
+++ b/scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R
@@ -7,8 +7,8 @@ library(here)
 #' @param tramitacoes_datapath Caminho para o CSV de tramitações.
 #' @return Dataframe com informações de proposições com parecer aprovado em comissões.
 #' @examples
-#' process_criterio_parecer_aprovado_comissao()
-process_criterio_parecer_aprovado_comissao <- function(
+#' process_criterio_avancou_comissoes()
+process_criterio_avancou_comissoes <- function(
   proposicoes_datapath = here::here("leggo_data/proposicoes.csv"),
   tramitacoes_datapath = here::here("leggo_data/trams.csv")) {
   # tramitacoes <- read_csv("~/leggo_data/trams.csv")

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -40,8 +40,9 @@ process_proposicoes_destaques <- function(
   proposicoes_criterio_avancou_comissoes <-
     process_criterio_avancou_comissoes(proposicoes_datapath,
                                                  tramitacoes_datapath) %>%
-    mutate(criterio_avancou_comissoes = T) %>%
-    select(id_leggo, id_ext, casa, criterio_avancou_comissoes, comissoes_aprovadas)
+    mutate(criterio_avancou_comissoes = ccj_camara | parecer_aprovado_comissao) %>%
+    filter(criterio_avancou_comissoes) %>%
+    select(id_leggo, criterio_avancou_comissoes, ccj_camara, parecer_aprovado_comissao)
 
   proposicoes_pressao_alta <-
     process_criterio_pressao_alta(pressao_datapath) %>%
@@ -57,7 +58,7 @@ process_proposicoes_destaques <- function(
     left_join(proposicoes_criterio_aprovada_em_uma_casa,
                by = c("id_leggo")) %>%
     left_join(proposicoes_criterio_avancou_comissoes,
-              by = c("id_leggo", "id_ext", "casa")) %>%
+              by = c("id_leggo")) %>%
     left_join(proposicoes_pressao_alta,
               by = c("id_leggo")) %>%
     left_join(proposicoes_criterio_mais_comentadas_twitter,

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -9,7 +9,7 @@ process_proposicoes_destaques <- function(
   library(lubridate)
 
   source(here::here("scripts/proposicoes/destaques/process_criterio_aprovada_em_uma_casa.R"))
-  source(here::here("scripts/proposicoes/destaques/process_criterio_parecer_aprovado_comissao.R"))
+  source(here::here("scripts/proposicoes/destaques/process_criterio_avancou_comissoes.R"))
   source(here::here("scripts/proposicoes/destaques/process_criterio_pressao_alta.R"))
   source(here::here("scripts/proposicoes/destaques/fetcher_criterio_mais_comentadas_twitter.R"))
 
@@ -37,11 +37,11 @@ process_proposicoes_destaques <- function(
     mutate(criterio_aprovada_em_uma_casa = T) %>%
     select(id_leggo, criterio_aprovada_em_uma_casa, fase_global, local, local_casa, data_inicio, data_fim)
 
-  proposicoes_criterio_parecer_aprovado_comissao <-
-    process_criterio_parecer_aprovado_comissao(proposicoes_datapath,
+  proposicoes_criterio_avancou_comissoes <-
+    process_criterio_avancou_comissoes(proposicoes_datapath,
                                                  tramitacoes_datapath) %>%
-    mutate(criterio_parecer_aprovado_comissao = T) %>%
-    select(id_leggo, id_ext, casa, criterio_parecer_aprovado_comissao, comissoes_aprovadas)
+    mutate(criterio_avancou_comissoes = T) %>%
+    select(id_leggo, id_ext, casa, criterio_avancou_comissoes, comissoes_aprovadas)
 
   proposicoes_pressao_alta <-
     process_criterio_pressao_alta(pressao_datapath) %>%
@@ -56,14 +56,14 @@ process_proposicoes_destaques <- function(
   proposicoes_destaques <- proposicoes %>%
     left_join(proposicoes_criterio_aprovada_em_uma_casa,
                by = c("id_leggo")) %>%
-    left_join(proposicoes_criterio_parecer_aprovado_comissao,
+    left_join(proposicoes_criterio_avancou_comissoes,
               by = c("id_leggo", "id_ext", "casa")) %>%
     left_join(proposicoes_pressao_alta,
               by = c("id_leggo")) %>%
     left_join(proposicoes_criterio_mais_comentadas_twitter,
               by = c("id_leggo")) %>%
     mutate(criterio_aprovada_em_uma_casa = !is.na(criterio_aprovada_em_uma_casa),
-           criterio_parecer_aprovado_comissao = !is.na(criterio_parecer_aprovado_comissao),
+           criterio_avancou_comissoes = !is.na(criterio_avancou_comissoes),
            criterio_pressao_alta = !is.na(criterio_pressao_alta),
            criterio_mais_comentadas_twitter = !is.na(criterio_mais_comentadas_twitter)) %>%
     left_join(interesses, by = c("id_leggo"))


### PR DESCRIPTION
## Mudanças
- Passa a considerar a passagem ou presença na CCJ como critério de seleção para as proposições da câmara.
- Passa a considerar os eventos que aconteceram nos últimos 4 anos.