### PR TITLE
Adiciona critérios de urgência ao csv final de destaques

### DIFF
--- a/scripts/proposicoes/destaques/process_criterio_requerimento_urgencia.R
+++ b/scripts/proposicoes/destaques/process_criterio_requerimento_urgencia.R
@@ -27,12 +27,13 @@ process_criterio_requerimento_urgencia <- function(trams_datapath = here::here("
     dplyr::filter(idade <= 4)
 
   proposicoes_requerimento_urgencia <- trams %>%
-  left_join(props, by = c("id_ext", "casa")) %>%
-  filter(str_detect(evento, "requerimento_urgencia_apresentado|requerimento_urgencia_aprovado"))
+    left_join(props, by = c("id_ext", "casa")) %>%
+    filter(str_detect(evento, "requerimento_urgencia_apresentado|requerimento_urgencia_aprovado"))
 
   # remove as repetições de proposições
-  proposicoes_sem_repetidos <- proposicoes_requerimento_urgencia %>% arrange(id_leggo, id_ext, casa, data) %>%
-    distinct(id_leggo, id_ext, casa, .keep_all = TRUE)
+  proposicoes_sem_repetidos <- proposicoes_requerimento_urgencia %>%
+    arrange(id_leggo, id_ext, casa, evento, data) %>%
+    distinct(id_leggo, id_ext, casa, evento, .keep_all = TRUE)
 
   proposicoes_requerimento_urgencia_final <-
     proposicoes_sem_repetidos %>%
@@ -54,10 +55,6 @@ process_criterio_requerimento_urgencia <- function(trams_datapath = here::here("
     fill(requerimento_urgencia_aprovado, .direction = "downup") %>%
     fill(casa_req_urgencia_apresentacao, .direction = "downup") %>%
     fill(casa_req_urgencia_aprovacao, .direction = "downup") %>%
-    mutate(
-      requerimento_urgencia_apresentado = max(requerimento_urgencia_apresentado),
-      requerimento_urgencia_aprovado = max(requerimento_urgencia_aprovado)
-    ) %>%
     ungroup() %>%
     select(
       id_leggo,
@@ -66,7 +63,8 @@ process_criterio_requerimento_urgencia <- function(trams_datapath = here::here("
       casa_req_urgencia_apresentacao,
       casa_req_urgencia_aprovacao
     ) %>%
-    distinct()
+    arrange(desc(data_req_urgencia_aprovacao), desc(data_req_urgencia_apresentacao)) %>%
+    distinct(id_leggo, .keep_all = TRUE)
 
   return(proposicoes_requerimento_urgencia_final)
 

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -37,7 +37,9 @@ process_proposicoes_destaques <- function(
                           col_types = cols(id_ext = col_character())) %>%
     filter(status == "Ativa") %>%
     mutate(sigla = paste0(sigla_tipo, " ", numero, "/", year(ymd_hms(data_apresentacao)))) %>%
-    select(id_leggo, id_ext, casa, sigla) %>%
+    mutate(casa_origem = if_else(is.na(casa_origem), "camara", casa_origem),
+           casa_revisora = if_else(casa_origem == "camara", "senado", "camara")) %>%
+    select(id_leggo, id_ext, casa, sigla, casa_origem, casa_revisora) %>%
     distinct()
 
   proposicoes_criterio_aprovada_em_uma_casa <-
@@ -116,14 +118,29 @@ process_proposicoes_destaques_limpo = function(
   interesses_datapath = here::here("leggo_data/interesses.csv"),
   pressao_datapath = here::here("leggo_data/pressao.csv")) {
 
-  proposicoes_destaques = process_proposicoes_destaques(proposicoes_datapath, progressos_datapath, tramitacoes_datapath, interesses_datapath, pressao_datapath) %>%
+  proposicoes_destaques = process_proposicoes_destaques(
+    proposicoes_datapath,
+    progressos_datapath,
+    tramitacoes_datapath,
+    interesses_datapath,
+    pressao_datapath
+  ) %>%
     select(id_leggo,
+           casa_origem,
+           casa_revisora,
            criterio_aprovada_em_uma_casa,
            casa_aprovacao = local_casa,
            data_aprovacao = data_fim,
            criterio_avancou_comissoes,
            comissoes_camara = sigla_local,
-           comissoes_senado = comissoes_aprovadas)
+           comissoes_senado = comissoes_aprovadas,
+           criterio_req_urgencia_apresentado,
+           casa_req_urgencia_apresentado = casa_req_urgencia_apresentacao,
+           data_req_urgencia_apresentado = data_req_urgencia_apresentacao,
+           criterio_req_urgencia_aprovado,
+           casa_req_urgencia_aprovado = casa_req_urgencia_aprovacao,
+           data_req_urgencia_aprovado = data_req_urgencia_aprovacao
+           )
 
   return(proposicoes_destaques)
 }

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -35,7 +35,10 @@ process_proposicoes_destaques <- function(
 
   proposicoes <- read_csv(proposicoes_datapath,
                           col_types = cols(id_ext = col_character())) %>%
-    filter(status == "Ativa") %>%
+    group_by(id_leggo) %>%
+    mutate(estado = paste(status, collapse = ";")) %>%
+    ungroup() %>%
+    filter(estado %in% c("Ativa", "Ativa;Ativa")) %>%
     mutate(sigla = paste0(sigla_tipo, " ", numero, "/", year(ymd_hms(data_apresentacao)))) %>%
     mutate(casa_origem = if_else(is.na(casa_origem), "camara", casa_origem),
            casa_revisora = if_else(casa_origem == "camara", "senado", "camara")) %>%

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -125,11 +125,12 @@ process_proposicoes_destaques_limpo = function(
     interesses_datapath,
     pressao_datapath
   ) %>%
+    mutate(casa_aprovacao = if_else(local_casa == "camara", "senado", "camara")) %>%
     select(id_leggo,
            casa_origem,
            casa_revisora,
            criterio_aprovada_em_uma_casa,
-           casa_aprovacao = local_casa,
+           casa_aprovacao,
            data_aprovacao = data_fim,
            criterio_avancou_comissoes,
            comissoes_camara = sigla_local,


### PR DESCRIPTION
## Mudanças
- Adiciona critérios de urgência ao csv final de destaques
- Adiciona colunas para identificação da casa revisora e da casa de origem

CSV gerado: https://drive.google.com/file/d/1xFoxxCZxgfbLSUdupMELbtBaZXxioOzR/view?usp=sharing