### PR TITLE
Disciplina partidaria

### DIFF
--- a/scripts/disciplina/process_disciplina.R
+++ b/scripts/disciplina/process_disciplina.R
@@ -5,8 +5,7 @@ library(perfilparlamentar)
 #' @description Recupera informações de disciplina partidária
 #' para o parlametria usando o pacote perfilparlamentar
 #' @param votos_datapath Caminho para o csv de votos.
-#' @param orientacoes_datapath Caminho para o csv de orientações.
-#' @param votacoes_datapath Caminho para o csv de votações.
+#' @param orientacoes_datapath Caminho para o csv de orientações
 #' @return Dataframe de parlamentares e a disciplina calculada.
 #' @example
 #' disciplina <- processa_disciplina(votos_datapath, orientacoes_datapath, votacoes_datapath)
@@ -22,9 +21,26 @@ processa_disciplina <-
   votos <- read_csv(votos_datapath) %>% 
     filter(id_votacao %in% (votacoes %>% pull(id_votacao)))
   
-  orientacoes <- read_csv(orientacoes_datapath)
+  orientacoes <- read_csv(orientacoes_datapath) %>% 
+    filter(id_votacao %in% (votacoes %>% pull(id_votacao)))
   
-  disciplina <- perfilparlamentar::processa_disciplina_partidaria(votos, orientacoes)
+  if (nrow(votos) > 0 && nrow(orientacoes) > 0) {
+    disciplina <- perfilparlamentar::processa_disciplina_partidaria(votos, orientacoes, FALSE)
+  
+  } else {
+    disciplina <- tibble(
+      id_parlamentar = integer(),
+      id_parlamentar_parlametria = integer(),
+      partido_disciplina = character(),
+      partido_atual = character(),
+      casa = character(),
+      votos_validos = integer(),
+      num_seguiu = integer(),
+      disciplina = double(),
+      bancada_suficiente = logical()
+    )
+  }
+  
   
   return(disciplina)
 }

--- a/scripts/governismo/process_governismo.R
+++ b/scripts/governismo/process_governismo.R
@@ -32,18 +32,26 @@ processa_governismo <-
   votos_camara <- votos %>%
     filter(casa == "camara") %>%
     distinct(id_votacao, id_parlamentar, .keep_all = TRUE)
-
-  governismo_camara <- perfilparlamentar::processa_governismo(votos_camara) %>%
-    select(id_parlamentar, governismo = D1) %>%
-    mutate(casa = "camara", governismo = -governismo)
+  
+  if (nrow(votos_camara) > 0) {
+    governismo_camara <- perfilparlamentar::processa_governismo(votos_camara) %>%
+      select(id_parlamentar, governismo = D1) %>%
+      mutate(casa = "camara", governismo = -governismo)
+  } else {
+    governismo_camara <- tibble()
+  }
 
   votos_senado <- votos %>%
     filter(casa == "senado") %>%
     distinct(id_votacao, id_parlamentar, .keep_all = TRUE)
-
-  governismo_senado <- perfilparlamentar::processa_governismo(votos_senado) %>%
-    select(id_parlamentar, governismo = D1) %>%
-    mutate(casa = "senado", governismo = -governismo)
+  
+  if(nrow(votos_senado) > 0) {
+    governismo_senado <- perfilparlamentar::processa_governismo(votos_senado) %>%
+      select(id_parlamentar, governismo = D1) %>%
+      mutate(casa = "senado", governismo = -governismo)
+  } else {
+    governismo_senado <- tibble()
+  }
 
   governismo_alt <- bind_rows(governismo_camara, governismo_senado) %>%
     group_by(casa) %>%


### PR DESCRIPTION
### Mudanças

- Adiciona filtro em orientações para considerar apenas votações que ocorreram no intervalo dos parâmetros;
- Checa se existem votos e orientações antes de processar a disciplina partidária;
- Checa se existem votos antes de processar o governismo em casa casa.

**OBS:** Depende da aprovação do [PR](https://github.com/parlametria/perfil-parlamentarR/pull/20) no perfil-parlamentarR.