### PR TITLE
Altera flag do congresso remoto para considerar a instalação de comissões

### DIFF
--- a/R/analyzer.R
+++ b/R/analyzer.R
@@ -484,7 +484,7 @@ get_progresso <- function(full_proposicao_df, full_tramitacao_df) {
 
   progresso_data <-
     extract_casas(full_proposicao_df, full_tramitacao_df, sigla[[1]]) %>%
-    generate_progresso_df(sigla[[1]], flag_cong_remoto = TRUE) %>%
+    generate_progresso_df(sigla[[1]], flag_cong_remoto = FALSE) %>%
     ## TODO: isso está ruim, deveria usar o id da proposição e não da etapa...
     tidyr::fill(prop_id, casa) %>%
     tidyr::fill(prop_id, casa, .direction = "up")

--- a/R/congresso-lib.R
+++ b/R/congresso-lib.R
@@ -99,7 +99,7 @@ extract_casas <- function(full_proposicao_df, full_tramitacao_df, sigla){
 #' @return Dataframe contendo o id da PL, as fases globais, data de inicio, data de fim
 #' @examples
 #'  generate_progresso_df(tramitacao_df)
-generate_progresso_df <- function(tramitacao_df, sigla, flag_cong_remoto = TRUE) {
+generate_progresso_df <- function(tramitacao_df, sigla, flag_cong_remoto = FALSE) {
 
   if (flag_cong_remoto) {
     tramitacao_df <- tramitacao_df %>%

--- a/R/congresso-lib.R
+++ b/R/congresso-lib.R
@@ -496,6 +496,20 @@ get_linha_finalizacao_tramitacao <- function(proc_tram_df) {
         df <- df %>%
           .corrige_fase_plenario_pre_comissoes()
       }
+    } else {
+      data_inicio_plenario <-
+        eventos_tramitacao_plenario %>% dplyr::pull(data_hora)
+
+      df <- df %>%
+        dplyr::mutate(
+          data_inicio = ifelse(
+            casa == "camara" & local == "Plenário",
+            data_inicio_plenario,
+            data_inicio
+          )
+        ) %>%
+        dplyr::mutate(data_inicio = as.POSIXct(data_inicio, origin = "1970-01-01")
+        )
     }
   }
   return(df)

--- a/tests/testthat/test-progresso.R
+++ b/tests/testthat/test-progresso.R
@@ -13,7 +13,6 @@ setup <- function(){
   etapas_pec %<>% purrr::pmap(dplyr::bind_rows)
   progresso_pec <<- get_progresso(etapas_pec$proposicao, etapas_pec$fases_eventos)
 
-
   etapas_pls_plenario_1 <<- list()
   etapas_pls_plenario_1 %<>% append(list(process_etapa(2209381, "camara", as.data.frame())))
   etapas_pls_plenario_1 %<>% purrr::pmap(dplyr::bind_rows)
@@ -81,7 +80,7 @@ test <- function() {
       tibble::tribble(
         ~ casa, ~ prop_id, ~ fase_global,      ~ local,                     ~ data_inicio,        ~ data_fim,     ~ local_casa,
       "camara", 1198512, "Construção",          "Plenário",                 "2020-07-21 16:18:00", "2020-07-22 00:00:00", "camara",
-      "camara", 1198512, "Construção",          "Comissões",                "2015-04-23 17:14:00", "2020-07-21 00:00:00", "camara",
+      "camara", 1198512, "Construção",          "Comissões",                "2015-04-23 17:14:00", "2020-07-21 18:47:00", "camara",
       "camara", 1198512, "Pré-Construção",      "",                         NA,                    NA,                  NA,
       "camara", 1198512, "Pré-Revisão I",       "",                         NA,                    NA,                  NA,
       "camara", 1198512, "Revisão I",           "Comissões",                NA,                    NA,                  NA,
@@ -93,16 +92,13 @@ test <- function() {
       "camara", 1198512, "Avaliação dos Vetos", "Congresso",                NA,                    NA,                  "congresso" )
 
     progresso_pec_gabarito <-
-      progresso_pec_gabarito %>% dplyr::mutate(prop_id = as.integer(prop_id),
-                                         data_fim = as.POSIXct(data_fim))
+      progresso_pec_gabarito %>% dplyr::mutate(prop_id = as.integer(prop_id))
 
     expect_equal(progresso_pec %>% dplyr::mutate(data_inicio = as.character(data_inicio)), progresso_pec_gabarito)
-
-
   })
 }
 check_api <- function() {
-  tryCatch(setup(), error = function(e){return(FALSE)})
+  tryCatch(setup(), error = function(e){ message(e); return(FALSE)})
 }
 
 if(check_api()){


### PR DESCRIPTION
## Mudanças
- Desativa flag do congresso remoto para considerar a nova instalação de comissões

## Flags
- Proposições usadas para teste
[PL 2895/2020](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2253704)
[PL 2291/2020](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2250879)
[PL 2398/2020](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2251625)
[PL 1380/2020](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2242646)
[PL 3063/2020](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2254270)
[PL 3144/2020](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2254585)