### PR TITLE
Modifica módulo de apensadas para recuperar informação da proposição principal raiz

### DIFF
--- a/scripts/proposicoes/apensadas/README.md
+++ b/scripts/proposicoes/apensadas/README.md
@@ -1,0 +1,44 @@
+# Módulo apensadas
+
+Este módulo é responsável por processar os dados de proposições apensadas monitoradas pelo Parlametria. Este processamento envolve criar um csv com a lista de proposições apensadas e o mapeamento para o id da proposição principal (na casa de origem), o id da proposição principal raiz da árvore de apensados (na casa de origem) e o id da proposição principal raiz no Parlametria.
+
+## Arquivos
+
+### **export_apensadas.R**
+
+Arquivo que fornece uma interface via linha de comando para executar o processamento das apensadas e salvar em CSV. São inputs para o processamento: o caminho para o csv de proposições (metadados - proposicoes.csv) processado pelo pacote do leggoR, caminho para o csv de interesses.csv com o mapeamento de proposições monitoradas e seus interesse no Parlametria, caminho para exportação dos dados de proposições apensadas.
+
+Uso:
+
+```
+Rscript export_apensadas.R -p <caminho_para_proposicoes.csv> -i <caminho_para_interesses.csv> -o <caminho_para_export_folder>
+```
+
+### **process_apensadas.R**
+Arquivo principal para execução do processamento de apensadas. Neste arquivo existem funções para processar o dataframe de apensadas que será exportado como csv e o dataframe de proposições apensadas que ainda não tem sua proposição principal raiz monitorada (função *process_apensadas*).
+
+Uma **proposição principal raiz** é a proposição principal na qual todas as outras proposições da árvore de apensamentos estão apensadas. Por exemplo, a proposição [2250675](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2250675) é uma proposição apensada. A sua proposição principal é a [2123222](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2123222), mas sua proposição principal raiz é a [2190084](https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2190084).
+
+Neste script também existem funções internas (*.find_proposicao_raiz* *.get_proposicao_raiz*, *.get_proposicao_raiz_from_lista*) que a partir de uma lista já processada com os links (proposição apensada -> proposição raiz) recuperam as proposição principal raiz de uma proposição apensada.
+
+### **process_lista_apensadas.R**
+
+Este arquivo é responsável por processar uma lista que tem como chave o id da proposição apensada e como valor o id da proposição principal. Neste arquivo existe a lógica para processar e salvar essa lista em csv, bem como reaproveitar a execução anterior dessa lista para percorrer nós já percorridos. Proposições principais que já são monitoradas pelo Parlametria e que já tiveram seus ids checados em busca de apensamentos a outras proposições terão o valor "raiz" considerado na lista da árvore de apensados.
+
+A função *process_lista_apensadas* processa as duas listas da árvore de apensados para câmara e para o senado separadamente. A função *process_lista_apensadas_por_casa* executa o processamento por casa, reaproveitando ou não a execução anterior. A função *fetch_proposicao_raiz* checa se a proposição chave já teve sua proposição principal pesquisada ou seja se está presente na lista, se não então faz a verificação usando a função agoradigital::fetch_proposicao e recuperando o campo uri_prop_principal. Este procedimento é repetido recursivamente até se encontrar a proposição que tem uri_prop_principal como NULL ou como raiz, sendo assim a proposição principal raiz.
+
+## Arquivos de saída
+
+### **props_apensadas.csv**
+Lista de proposições apensadas que serão importadas para o BD do Parlametria.
+Neste csv temos a informação da proposição apensada no Parlametria (id_leggo), da proposição principal (id_ext_prop_principal), da casa da proposição principal raiz, do id_leggo da proposição principal raiz e do id da proposição principal raiz (casa_prop_principal, id_leggo_prop_principal, id_ext_prop_principal_raiz, respectivamente), e o interesse.
+
+### **props_apensadas_nao_monitoradas.csv**
+Lista de proposições apensadas que tem proposições principais (raiz) que não são monitoradas pelo Parlametria ou não são monitoradas dentro do mesmo painel. Este arquivo é usado como log de execução e para facilitar a identificação destes casos que precisam ser observados/notados.
+
+### **lista_apensadas_camara.csv**
+Dataframe para o contexto da câmara com o par chave->valor no qual proposição apensada -> proposição raiz. Este csv é transformado em lista para o processamento das proposições apensadas.
+
+### **lista_apensadas_senado.csv**
+Dataframe para o contexto do senado com o par chave->valor no qual proposição apensada -> proposição raiz. Este csv é transformado em lista para o processamento das proposições apensadas.
+

--- a/scripts/proposicoes/apensadas/export_apensadas.R
+++ b/scripts/proposicoes/apensadas/export_apensadas.R
@@ -49,7 +49,7 @@ if (!str_detect(export_path, "\\/$")) {
 }
 
 flog.info("Processando dados de proposições apensadas")
-list_props_apensadas <- process_apensadas(proposicoes_filepath, interesses_filepath)
+list_props_apensadas <- process_apensadas(proposicoes_filepath, interesses_filepath, export_path)
 
 props_apensadas <- list_props_apensadas[[1]]
 props_apensadas_nao_monitoradas <- list_props_apensadas[[2]]

--- a/scripts/proposicoes/apensadas/process_apensadas.R
+++ b/scripts/proposicoes/apensadas/process_apensadas.R
@@ -2,6 +2,8 @@ library(tidyverse)
 library(futile.logger)
 library(agoradigital)
 
+source(here::here("scripts/proposicoes/apensadas/process_lista_apensadas.R"))
+
 #' @title Processa proposições apensadas
 #' @description Realiza o processamento das proposições apensadas para o formato usado pelo Parlametria
 #' @param proposicoes_filepath Caminho para o CSV de proposições
@@ -21,26 +23,22 @@ process_apensadas <- function(proposicoes_filepath, interesses_filepath, export_
     select(id_ext, casa, id_leggo, uri_prop_principal) %>%
     .extract_id_from_uri()
 
-  process_lista_apensadas(proposicoes_apensadas, fresh_execution = FALSE, export_folder)
+  listas <- process_lista_apensadas(proposicoes_apensadas, fresh_execution = FALSE, export_folder)
 
-  proposicoes_apensadas <- proposicoes %>%
-    filter(!is.na(uri_prop_principal)) %>%
-    select(id_ext, casa, id_leggo, uri_prop_principal) %>%
-    .extract_id_from_uri() %>%
-    get_proposicao_principal_raiz()
+  proposicoes_apensadas_com_prop_raiz <- .find_proposicao_raiz(proposicoes_apensadas, listas)
 
-  flog.info(str_glue("{proposicoes_apensadas %>% nrow()} proposições monitoradas são proposições apensadas."))
+  flog.info(str_glue("{proposicoes_apensadas_com_prop_raiz %>% nrow()} proposições monitoradas são proposições apensadas."))
 
-  props_apensadas <- proposicoes_apensadas %>%
+  props_apensadas <- proposicoes_apensadas_com_prop_raiz %>%
     left_join(proposicoes %>% select(id_ext, casa, id_leggo_principal = id_leggo),
-              by = c("id_prop_principal" = "id_ext", "casa")) %>%
+              by = c("id_prop_principal_raiz" = "id_ext", "casa")) %>%
     left_join(interesses, by = "id_leggo") %>%
     left_join(interesses %>% select(id_leggo_principal = id_leggo, interesse_prop_principal = interesse),
               by = "id_leggo_principal") %>%
     mutate(id_leggo_principal = if_else(interesse == interesse_prop_principal, id_leggo_principal, NA_character_))
 
   flog.info(str_glue("{props_apensadas %>% filter(!is.na(id_leggo_principal)) %>% distinct(id_ext, casa) %>% nrow()}",
-                     " proposições monitoradas têm sua proposição principal também monitorada."))
+                     " proposições monitoradas têm sua proposição principal raiz também monitorada."))
 
   flog.info(str_glue("{props_apensadas %>% filter(is.na(id_leggo_principal), !is.na(interesse_prop_principal)) %>%
                      distinct(id_ext, casa) %>% nrow()}",
@@ -50,14 +48,15 @@ process_apensadas <- function(proposicoes_filepath, interesses_filepath, export_
     arrange(id_leggo, id_leggo_principal) %>%
     distinct(id_leggo, .keep_all = T) %>%
     select(id_leggo, id_leggo_prop_principal = id_leggo_principal, id_ext_prop_principal = id_prop_principal,
-           casa_prop_principal = casa, interesse)
+           id_ext_prop_principal_raiz = id_prop_principal_raiz, casa_prop_principal = casa, interesse)
 
   props_apensadas_nao_monitoradas <- props_apensadas_alt %>%
     filter(is.na(id_leggo_prop_principal)) %>%
     left_join(proposicoes %>% distinct(id_ext, casa, id_leggo), by = c("id_leggo", "casa_prop_principal" = "casa")) %>%
-    select(id_leggo, id_ext, casa = casa_prop_principal, id_leggo_prop_principal, id_ext_prop_principal)
+    select(id_leggo, id_ext, casa = casa_prop_principal, id_leggo_prop_principal, id_ext_prop_principal,
+           id_ext_prop_principal_raiz)
 
-  flog.info(str_glue("{props_apensadas_nao_monitoradas %>% nrow()} proposições monitoradas não têm a proposição principal monitorada"))
+  flog.info(str_glue("{props_apensadas_nao_monitoradas %>% nrow()} proposições monitoradas não têm a proposição principal raiz monitorada"))
 
   return(list(props_apensadas_alt, props_apensadas_nao_monitoradas))
 }
@@ -79,12 +78,57 @@ process_apensadas <- function(proposicoes_filepath, interesses_filepath, export_
   return(proposicoes_com_id)
 }
 
-#' @title Recupera o id da proposição que é a raiz da árvore de apensados da proposição de interesse
-#' @param proposicoes Dataframe de proposições com pelo menos uma coluna: id_prop_principal
+#' @title Recupera os ids das proposições que são as raizes das árvores de apensados da proposição apensada monitorada
+#' @param proposicoes_apensadas Dataframe de proposições com pelo menos três colunas: id_ext, casa, id_prop_principal
+#' @param listas Lista resultado do retorno do processamento da lista da árvore de apensadas da função process_lista_apensadas
 #' @return Dataframe com as mesmas colunas originais e uma coluna a mais com o id da proposição raiz (id_prop_principal_raiz)
-get_proposicao_principal_raiz <- function(proposicoes) {
-  proposicoes_processadas <- proposicoes %>%
-    mutate(id_prop_principal_raiz = id_prop_principal)
+.find_proposicao_raiz <- function(proposicoes_apensadas, listas) {
+  apensadas_camara <- listas[[1]]
+  apensadas_senado <- listas[[2]]
 
-  return(proposicoes_processadas)
+  proposicoes_filtradas <- proposicoes_apensadas %>%
+    filter(!is.na(uri_prop_principal))
+
+  proposicoes_processadas <- map2_df(proposicoes_filtradas$id_ext, proposicoes_filtradas$casa,
+                                     ~ .get_proposicao_raiz(.x, .y, apensadas_camara, apensadas_senado)) %>%
+    mutate(id_prop_principal_raiz = if_else(id_prop == id_prop_principal_raiz, NA_character_, id_prop_principal_raiz)) %>%
+    distinct(id_prop, casa_origem, .keep_all = TRUE)
+
+  proposicoes_merge <- proposicoes_filtradas %>%
+    left_join(proposicoes_processadas, by = c("id_ext" = "id_prop", "casa" = "casa_origem"))
+
+  return(proposicoes_merge)
+}
+
+#' @title Recupera o id da proposição que é raiz na árvore de apensados da proposição apensada monitorada
+#' @param id_prop Id da proposição apensadas
+#' @param casa_origem Casa de origem da proposição apensada
+#' @param apensadas_camara Árvore de apensadas da Câmara
+#' @param apensadas_senado Árvore de apensadas do Senado
+#' @return Dataframe com o mapeamento entre a proposição (id_prop, casa_origem) e sua proposição principal raiz (id_prop_principal_raiz)
+.get_proposicao_raiz <- function(id_prop, casa_origem, apensadas_camara, apensadas_senado) {
+
+  if (casa_origem == "camara") {
+    lista_apensadas <- apensadas_camara
+  } else if (casa_origem == "senado") {
+    lista_apensadas <- apensadas_senado
+  } else {
+    stop("Casa de origem inválida. Deve ser 'camara' ou 'senado'")
+  }
+
+  id_prop_principal_raiz <- .get_proposicao_raiz_from_lista(id_prop, lista_apensadas)
+
+  return(tibble(id_prop, casa_origem, id_prop_principal_raiz))
+}
+
+#' @title Procura pela proposição raiz na lista da árvore de apensadas passada como parâmetro
+#' @param id_prop Id da proposição apensadas
+#' @param lista_apensadas Lista com árvore de apensadas capturada para a casa de origem da proposição
+#' @return Id da proposição raiz
+.get_proposicao_raiz_from_lista <- function(id_prop, lista_apensadas) {
+  if (is.null(lista_apensadas[[id_prop]]) || lista_apensadas[[id_prop]] == 'raiz') {
+    return(id_prop)
+  } else {
+    .get_proposicao_raiz_from_lista(lista_apensadas[[id_prop]], lista_apensadas)
+  }
 }

--- a/scripts/proposicoes/apensadas/process_apensadas.R
+++ b/scripts/proposicoes/apensadas/process_apensadas.R
@@ -21,7 +21,7 @@ process_apensadas <- function(proposicoes_filepath, interesses_filepath, export_
 
   proposicoes_apensadas <- proposicoes %>%
     select(id_ext, casa, id_leggo, uri_prop_principal) %>%
-    .extract_id_from_uri()
+    extract_id_from_uri()
 
   listas <- process_lista_apensadas(proposicoes_apensadas, fresh_execution = FALSE, export_folder)
 
@@ -64,7 +64,7 @@ process_apensadas <- function(proposicoes_filepath, interesses_filepath, export_
 #' @title Extrai id da URI da proposição na API da respectiva casa
 #' @param proposicoes Dataframe de proposições com pelo menos uma coluna: uri_prop_principal
 #' @return Dataframe com as mesmas colunas originais e uma coluna a mais com o id da proposição
-.extract_id_from_uri <- function(proposicoes) {
+extract_id_from_uri <- function(proposicoes) {
   proposicoes_com_id <- proposicoes %>%
     mutate(
       id_prop_principal = case_when(

--- a/scripts/proposicoes/apensadas/process_lista_apensadas.R
+++ b/scripts/proposicoes/apensadas/process_lista_apensadas.R
@@ -4,7 +4,7 @@ library(futile.logger)
 
 #' @title Processa lista de apensadas com árvore partindo das apensadas monitoradas até chegar na proposição raiz.
 #' @description Recupera uma lista que contém as ligações entre as proposições apensadas monitoradas e suas
-#' proposições principais
+#' proposições principais para as duas casas: câmara e senado.
 #' @param proposicoes_apensadas Dataframe com lista de proposições apensadas e suas proposições principais.
 #' É necessário pelo menos 3 colunas: id_ext, casa, id_prop_principal.
 #' @param fresh_execution Se FALSE então um arquivo com a lista de apensadas executada anteriormente será utilizada.
@@ -31,12 +31,12 @@ process_lista_apensadas <- function(proposicoes_apensadas, fresh_execution = FAL
     )
 
   flog.info("Processamento de árvore de apensadas concluído!")
-  return(list(lista_proposicoes_apensadas_camara, lista_senado))
+  return(list(lista_proposicoes_apensadas_camara, lista_proposicoes_apensadas_senado))
 }
 
 #' @title Processa lista de apensadas com árvore partindo das apensadas monitoradas até chegar na proposição raiz.
 #' @description Recupera uma lista que contém as ligações entre as proposições apensadas monitoradas e suas
-#' proposições principais
+#' proposições principais para uma casa de origem.
 #' @param proposicoes_apensadas Dataframe com lista de proposições apensadas e suas proposições principais.
 #' É necessário pelo menos 3 colunas: id_ext, casa, id_prop_principal.
 #' @param casa_origem Casa de origem das proposições. Parâmetro usado para recuperar dados da uriPrincipal.
@@ -49,7 +49,6 @@ process_lista_apensadas_por_casa <- function(proposicoes_apensadas,
                                              fresh_execution = FALSE,
                                              export_filepath = "lista_apensadas.csv") {
 
-  ##TODO leitura de lista de apensadas já usadas
   if (!fresh_execution) {
     if (file.exists(export_filepath)) {
       execucao_anterior_lista <- read_csv(export_filepath, col_types = cols(.default = "c")) %>%
@@ -92,10 +91,13 @@ process_lista_apensadas_por_casa <- function(proposicoes_apensadas,
 #' até chegar na proposição raiz. Salva na lista (objeto no environment global) as proposições apensadas (chave) e
 #' as prosições principais (valor). Este código não considera outras subárvores da árvore de apensadas da proposição
 #' passada como parâmetro.
+#' Na lista usada como estrutura de entrada: key é a proposição possivelmente apensada e value é a proposição principal
+#' Para o caso de proposições já monitoradas que não são apensadas o value é 'raiz'.
 #' @param x Lista de um elemento (ou string) com o id da proposição para pesquisar
+#' @param casa Casa de origem da proposição
 #' @return Elemento x passado como parâmetro
 fetch_proposicao_raiz <- function(x, casa) {
-  print(str_glue("k: {names(x)} v: {x[[1]]} casa: {casa}"))
+  print(str_glue("key: {names(x)} value: {x[[1]]} casa: {casa}"))
 
   id <- x[[1]]
   if (is.null(lista[[id]]) && id != "raiz") {

--- a/scripts/proposicoes/apensadas/process_lista_apensadas.R
+++ b/scripts/proposicoes/apensadas/process_lista_apensadas.R
@@ -43,11 +43,13 @@ process_lista_apensadas <- function(proposicoes_apensadas, fresh_execution = FAL
 #' @param fresh_execution Se FALSE então um arquivo com a lista de apensadas executada anteriormente será utilizada.
 #' TRUE caso uma execução nova seja o objetivo.
 #' @param export_filepath Caminho para salvar lista de apensadas
+#' @param save_result TRUE se o resultado da lista deve ser salvo em csv no caminho do export_filepath
 #' @return Lista com árvore de apensados.
 process_lista_apensadas_por_casa <- function(proposicoes_apensadas,
                                              casa_origem = "camara",
                                              fresh_execution = FALSE,
-                                             export_filepath = "lista_apensadas.csv") {
+                                             export_filepath = "lista_apensadas.csv",
+                                             save_result = TRUE) {
 
   if (!fresh_execution) {
     if (file.exists(export_filepath)) {
@@ -81,7 +83,9 @@ process_lista_apensadas_por_casa <- function(proposicoes_apensadas,
   lista_asdataframe <- stack(lista) %>%
     select(key = ind, value = values)
 
-  write_csv(lista_asdataframe, export_filepath)
+  if (save_result) {
+    write_csv(lista_asdataframe, export_filepath)
+  }
 
   return(lista)
 }
@@ -95,9 +99,12 @@ process_lista_apensadas_por_casa <- function(proposicoes_apensadas,
 #' Para o caso de proposições já monitoradas que não são apensadas o value é 'raiz'.
 #' @param x Lista de um elemento (ou string) com o id da proposição para pesquisar
 #' @param casa Casa de origem da proposição
+#' @param verbose TRUE para exibir mensagens sobre a execução da proposição atual, FALSE caso contrário.
 #' @return Elemento x passado como parâmetro
-fetch_proposicao_raiz <- function(x, casa) {
-  print(str_glue("key: {names(x)} value: {x[[1]]} casa: {casa}"))
+fetch_proposicao_raiz <- function(x, casa, verbose = TRUE) {
+  if (verbose) {
+    print(str_glue("key: {names(x)} value: {x[[1]]} casa: {casa}"))
+  }
 
   id <- x[[1]]
   if (is.null(lista[[id]]) && id != "raiz") {

--- a/scripts/proposicoes/apensadas/process_lista_apensadas.R
+++ b/scripts/proposicoes/apensadas/process_lista_apensadas.R
@@ -1,0 +1,126 @@
+library(tidyverse)
+library(here)
+library(futile.logger)
+
+#' @title Processa lista de apensadas com árvore partindo das apensadas monitoradas até chegar na proposição raiz.
+#' @description Recupera uma lista que contém as ligações entre as proposições apensadas monitoradas e suas
+#' proposições principais
+#' @param proposicoes_apensadas Dataframe com lista de proposições apensadas e suas proposições principais.
+#' É necessário pelo menos 3 colunas: id_ext, casa, id_prop_principal.
+#' @param fresh_execution Se FALSE então um arquivo com a lista de apensadas executada anteriormente será utilizada.
+#' TRUE caso uma execução nova seja o objetivo.
+#' @param export_folder Caminho do diretório para salvar lista de apensadas. Com / no final.
+#' @return Lista com árvore de apensados.
+process_lista_apensadas <- function(proposicoes_apensadas, fresh_execution = FALSE, export_folder) {
+  flog.info("Processando árvore de apensadas para Câmara")
+  lista_proposicoes_apensadas_camara <-
+    process_lista_apensadas_por_casa(
+      proposicoes_apensadas,
+      "camara",
+      fresh_execution,
+      export_filepath = str_glue(export_folder, "lista_apensadas_camara.csv")
+    )
+
+  flog.info("Processando árvore de apensadas para Senado")
+  lista_proposicoes_apensadas_senado <-
+    process_lista_apensadas_por_casa(
+      proposicoes_apensadas,
+      "senado",
+      fresh_execution,
+      export_filepath = str_glue(export_folder, "lista_apensadas_senado.csv")
+    )
+
+  flog.info("Processamento de árvore de apensadas concluído!")
+  return(list(lista_proposicoes_apensadas_camara, lista_senado))
+}
+
+#' @title Processa lista de apensadas com árvore partindo das apensadas monitoradas até chegar na proposição raiz.
+#' @description Recupera uma lista que contém as ligações entre as proposições apensadas monitoradas e suas
+#' proposições principais
+#' @param proposicoes_apensadas Dataframe com lista de proposições apensadas e suas proposições principais.
+#' É necessário pelo menos 3 colunas: id_ext, casa, id_prop_principal.
+#' @param casa_origem Casa de origem das proposições. Parâmetro usado para recuperar dados da uriPrincipal.
+#' @param fresh_execution Se FALSE então um arquivo com a lista de apensadas executada anteriormente será utilizada.
+#' TRUE caso uma execução nova seja o objetivo.
+#' @param export_filepath Caminho para salvar lista de apensadas
+#' @return Lista com árvore de apensados.
+process_lista_apensadas_por_casa <- function(proposicoes_apensadas,
+                                             casa_origem = "camara",
+                                             fresh_execution = FALSE,
+                                             export_filepath = "lista_apensadas.csv") {
+
+  ##TODO leitura de lista de apensadas já usadas
+  if (!fresh_execution) {
+    if (file.exists(export_filepath)) {
+      execucao_anterior_lista <- read_csv(export_filepath, col_types = cols(.default = "c")) %>%
+        select(id_ext = key, id_prop_principal = value)
+    } else {
+      execucao_anterior_lista <- tibble()
+    }
+  } else {
+    execucao_anterior_lista <- tibble()
+  }
+
+  props_apensadas <- proposicoes_apensadas %>%
+    filter(casa == casa_origem)
+
+  # Lista inicial com as proposições apensadas e suas proposições principais
+  lista_data <- bind_rows(props_apensadas, execucao_anterior_lista) %>%
+    distinct(id_ext, id_prop_principal) %>%
+    mutate(id_prop_principal = ifelse(is.na(id_prop_principal), "raiz", id_prop_principal))
+
+  lista <<- setNames(as.list(lista_data$id_prop_principal), lista_data$id_ext)
+
+  # Recuperando lista com árvore de apensadas
+  execucao_lista <- lista %>%
+    lmap(~fetch_proposicao_raiz(.x, casa = casa_origem))
+
+  # Removendo variáveis não utilizadas
+  rm(lista_data, execucao_lista, execucao_anterior_lista)
+
+  # Escrevendo dados da lista de apensadas
+  lista_asdataframe <- stack(lista) %>%
+    select(key = ind, value = values)
+
+  write_csv(lista_asdataframe, export_filepath)
+
+  return(lista)
+}
+
+#' @title Atualiza lista com proposições principais a partir de uma proposição apensada como parâmetro.
+#' @description Checa se uma proposição está apensada a outra e caminha pela árvore de apensadas
+#' até chegar na proposição raiz. Salva na lista (objeto no environment global) as proposições apensadas (chave) e
+#' as prosições principais (valor). Este código não considera outras subárvores da árvore de apensadas da proposição
+#' passada como parâmetro.
+#' @param x Lista de um elemento (ou string) com o id da proposição para pesquisar
+#' @return Elemento x passado como parâmetro
+fetch_proposicao_raiz <- function(x, casa) {
+  print(str_glue("k: {names(x)} v: {x[[1]]} casa: {casa}"))
+
+  id <- x[[1]]
+  if (is.null(lista[[id]]) && id != "raiz") {
+    uri_prop_principal <- agoradigital::fetch_proposicao(id, casa) %>% pull(uri_prop_principal)
+    if (is.na(uri_prop_principal)) {
+      return(x)
+    } else {
+      id_prop_principal <- .extract_id_prop(uri_prop_principal)
+      lista[[id]] <<- id_prop_principal
+      fetch_proposicao_raiz(id_prop_principal, casa)
+    }
+  }
+  return(x)
+}
+
+#' @title Extrai id da URI da proposição na API da respectiva casa
+#' @param uri URI da proposição
+#' @return Id da proposição extraído a partir da URI
+.extract_id_prop <- function(uri) {
+  id_prop <- case_when(
+        str_detect(uri, "dadosabertos.camara.leg.br") ~
+          uri %>% str_extract("proposicoes/[0-9]+") %>% str_extract("[0-9]+"),
+        str_detect(uri, "legis.senado.leg.br") ~
+          uri %>% str_extract("materia/[0-9]+") %>% str_extract("[0-9]+")
+      )
+
+  return(id_prop)
+}

--- a/tests/testthat/test-apensadas.R
+++ b/tests/testthat/test-apensadas.R
@@ -1,0 +1,71 @@
+testthat::context('test-apensadas.R')
+
+library(tidyverse)
+library(testthat)
+source(here::here("scripts/proposicoes/apensadas/process_lista_apensadas.R"))
+source(here::here("scripts/proposicoes/apensadas/process_apensadas.R"))
+
+#' @title Recupera proposição apensada no formato do dataframe usado para teste
+setup_prop_apensada <- function(id_prop, casa) {
+  prop <- agoradigital::fetch_proposicao(id_prop, casa) %>%
+    mutate(id_leggo = "idleggo1")
+
+  proposicao_apensada <- prop %>%
+    select(id_ext = prop_id, casa, id_leggo, uri_prop_principal) %>%
+    extract_id_from_uri()
+
+  return(proposicao_apensada)
+}
+
+test_that('setup_prop_apensada() retorna a proposição principal corretamente para a câmara', {
+  prop <- setup_prop_apensada("2250675", "camara")
+  expect_equal(prop$id_prop_principal, "2123222")
+})
+
+test_that('setup_prop_apensada() retorna NA quando não houver proposição principal', {
+  prop <- setup_prop_apensada("2190084", "camara")
+  expect_true(is.na(prop$id_prop_principal))
+})
+
+test_that('setup_prop_apensada() retorna a proposição principal corretamente para o senado', {
+  prop <- setup_prop_apensada("136606", "senado")
+  expect_equal(prop$id_prop_principal, "135978")
+})
+
+test_that('process_lista_apensadas_por_casa() retorna a lista correta de apensamentos', {
+  ## proposicao de teste PL 2215/2020 https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2250675
+  ## Data de acesso a página da PL 03/05/2021
+
+  prop <- setup_prop_apensada("2250675", "camara")
+
+  lista_apensadas <- process_lista_apensadas_por_casa(prop, "camara", fresh_execution = TRUE, save_result = FALSE)
+
+  lista_gabarito <- tibble(key = c("2250675", "2123222", "1203380", "517167"),
+                           value = c("2123222", "1203380", "517167", "2190084")) %>%
+    as.data.frame()
+
+  lista_dataframe <- stack(lista) %>%
+    select(key = ind, value = values) %>%
+    mutate(key = as.character(key))
+
+  expect_equal(lista_gabarito, lista_dataframe)
+})
+
+test_that('process_lista_apensadas_por_casa() retorna lista com raiz para proposição principal raiz', {
+  ## proposicao de teste PL 11247/2018 https://www.camara.leg.br/proposicoesWeb/fichadetramitacao?idProposicao=2190084
+  ## Data de acesso a página da PL 03/05/2021
+
+  prop <- setup_prop_apensada("2190084", "camara")
+
+  lista_apensadas <- process_lista_apensadas_por_casa(prop, "camara", fresh_execution = TRUE, save_result = FALSE)
+
+  lista_gabarito <- tibble(key = c("2190084"),
+                           value = c("raiz")) %>%
+    as.data.frame()
+
+  lista_dataframe <- stack(lista) %>%
+    select(key = ind, value = values) %>%
+    mutate(key = as.character(key))
+
+  expect_equal(lista_gabarito, lista_dataframe)
+})


### PR DESCRIPTION
## Mudanças
- Modifica módulo de apensadas para recuperar informação da proposição principal raiz
- Cria funções para recuperar, processar e salvar a proposição principal raiz
- Altera geração do csv de proposições apensadas para incluir nova coluna
- Adiciona readme ao módulo de apensadas
- Adiciona testes para a função de recuperação da lista de apensados

## Flags
- Sugestões de testes são bem-vindas