### PR TITLE
Corrige erro na build com docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM rocker/tidyverse:3.6.2
 WORKDIR /agora-digital
 
 #Prepare environment and copy files
-RUN apt-get update
+RUN apt-get update --allow-releaseinfo-change
 RUN apt-get install libssl-dev libxml2-dev libcurl4-openssl-dev libgit2-dev vim less git -y
-RUN apt-get update
+RUN apt-get update --allow-releaseinfo-change
 RUN apt-get install -y libjpeg-dev libpoppler-cpp-dev
 ENV TZ=America/Sao_Paulo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
Há um erro ao fazer a build com docker-compose:

![err-leggoR-build](https://user-images.githubusercontent.com/4295523/132913501-34b284e6-eb57-4a0a-ba27-95f42c2f859d.png)

Esse erro pode ser corrido adicionando `--allow-releaseinfo-change` nas linhas do `RUN apt-get update` no Dockerfile.
