### PR TITLE
Adiciona checagem de existência do csv de pressão antes de processar critério de destaque

### DIFF
--- a/scripts/proposicoes/destaques/process_criterio_pressao_alta.R
+++ b/scripts/proposicoes/destaques/process_criterio_pressao_alta.R
@@ -25,3 +25,30 @@ process_criterio_pressao_alta <- function(
 
   return(proposicoes_com_pressao)
 }
+
+#' @title Checa e processa o critério com pressão alta
+#' @description Checa se o arquivo de pressão existe antes
+#' de processar o critério de pressão alta das proposições
+#' @param pressao_datapath Datapath de pressão
+#' @return Dataframe contendo as proposições que passam no critério,
+#' com a informação da pressão em cada uma. Caso o csv de pressão não exista,
+#' será retornado um dataframe vazio.
+check_and_process_criterio_pressao_alta <-
+  function(pressao_filepath) {
+    if (file.exists(pressao_filepath)) {
+      proposicoes_pressao_alta <-
+        process_criterio_pressao_alta(pressao_datapath) %>%
+        mutate(criterio_pressao_alta = T) %>%
+        select(id_leggo, criterio_pressao_alta, maximo_pressao_periodo)
+      
+      return(proposicoes_pressao_alta)
+    } else {
+      return(
+        tibble(
+          id_leggo = character(),
+          criterio_pressao_alta = logical(),
+          maximo_pressao_periodo = numeric()
+        )
+      )
+    }
+  }

--- a/scripts/proposicoes/destaques/process_criterio_pressao_alta.R
+++ b/scripts/proposicoes/destaques/process_criterio_pressao_alta.R
@@ -34,13 +34,13 @@ process_criterio_pressao_alta <- function(
 #' com a informação da pressão em cada uma. Caso o csv de pressão não exista,
 #' será retornado um dataframe vazio.
 check_and_process_criterio_pressao_alta <-
-  function(pressao_filepath) {
-    if (file.exists(pressao_filepath)) {
+  function(pressao_datapath) {
+    if (file.exists(pressao_datapath)) {
       proposicoes_pressao_alta <-
-        process_criterio_pressao_alta(pressao_filepath) %>%
+        process_criterio_pressao_alta(pressao_datapath) %>%
         mutate(criterio_pressao_alta = T) %>%
         select(id_leggo, criterio_pressao_alta, maximo_pressao_periodo)
-      
+
       return(proposicoes_pressao_alta)
     } else {
       print("O csv de pressão não existe. Veja como gerá-lo no leggo-geral.")

--- a/scripts/proposicoes/destaques/process_criterio_pressao_alta.R
+++ b/scripts/proposicoes/destaques/process_criterio_pressao_alta.R
@@ -37,12 +37,13 @@ check_and_process_criterio_pressao_alta <-
   function(pressao_filepath) {
     if (file.exists(pressao_filepath)) {
       proposicoes_pressao_alta <-
-        process_criterio_pressao_alta(pressao_datapath) %>%
+        process_criterio_pressao_alta(pressao_filepath) %>%
         mutate(criterio_pressao_alta = T) %>%
         select(id_leggo, criterio_pressao_alta, maximo_pressao_periodo)
       
       return(proposicoes_pressao_alta)
     } else {
+      print("O csv de pressão não existe. Veja como gerá-lo no leggo-geral.")
       return(
         tibble(
           id_leggo = character(),

--- a/scripts/proposicoes/destaques/process_destaques.R
+++ b/scripts/proposicoes/destaques/process_destaques.R
@@ -72,9 +72,7 @@ process_proposicoes_destaques <- function(
            casa_req_urgencia_aprovacao)
 
   proposicoes_pressao_alta <-
-    process_criterio_pressao_alta(pressao_datapath) %>%
-    mutate(criterio_pressao_alta = T) %>%
-    select(id_leggo, criterio_pressao_alta, maximo_pressao_periodo)
+    check_and_process_criterio_pressao_alta(pressao_datapath)
 
   proposicoes_criterio_mais_comentadas_twitter <-
     fetch_proposicoes_mais_comentadas_twitter(interesses = interesses_agendas) %>%


### PR DESCRIPTION
# Mudanças

- Cria função que checa existência do arquivo de pressão antes de calcular o critério de pressão alta. Caso não exista, é retornado um dataframe vazio para este critério;
- Adiciona essa função no processamento das proposições de destaque.